### PR TITLE
ui: css wrap only filename

### DIFF
--- a/assets/stylesheets/overall.scss
+++ b/assets/stylesheets/overall.scss
@@ -183,10 +183,11 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
     min-width: 100%;
 }
 
-.break-long-content, .table td {
+.break-long-content {
     overflow-wrap: break-word;
     word-wrap: break-word;
     word-break: break-word;
+    white-space: unset !important;
 }
 
 .breadcrumb {
@@ -196,6 +197,6 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
 
 #container-download {
   width: 100%;
-  max-width: 720px;
+  max-width: 1080px;
   margin: auto;
 }

--- a/assets/stylesheets/tables.scss
+++ b/assets/stylesheets/tables.scss
@@ -70,6 +70,6 @@
     padding: 2px;
 }
 
-.table th {
+.table th, .table td {
     white-space: nowrap;
 }

--- a/templates/dir.html.ep
+++ b/templates/dir.html.ep
@@ -12,7 +12,7 @@
 
 <nav class="navbar navbar-expand-lg navbar-light bg-light mb-3 border-bottom">
   <div class="container">
-    <h5 class="break-long-content">Mirrors status: </h5>
+    <h5>Mirrors status: </h5>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarFolderStatus" aria-controls="navbarFolderStatus" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
     </button>
@@ -83,7 +83,7 @@
       </tr>
       % for my $file (@$files) {
       <tr>
-        <td class="name"><a href='<%= $file->{url} %>'><%== $file->{name} %></a></td>
+        <td class="name break-long-content"><a href='<%= $file->{url} %>'><%== $file->{name} %></a></td>
       %   if ($file->{mtime}) {
         <td class='size'><%= $file->{dir} ? '' : $file->{size} %></td>
         <td class='mtime'><%= $file->{mtime} %></td>


### PR DESCRIPTION
[skip ci] Previously values in date and size columns might wrap into two lines when filename is long.
This change attempts to make sure that only filename can wrap.