### PR TITLE
Rework creation of mirrorcache user and its home dir

### DIFF
--- a/dist/rpm/MirrorCache-tmpfilesd.conf
+++ b/dist/rpm/MirrorCache-tmpfilesd.conf
@@ -1,0 +1,2 @@
+# Type Path Mode UID GID Age Argument
+d /var/lib/mirrorcache 0750 mirrorcache - - -

--- a/dist/rpm/MirrorCache-user.conf
+++ b/dist/rpm/MirrorCache-user.conf
@@ -1,0 +1,2 @@
+# Type Name ID GECOS [HOME]
+u mirrorcache - "MirrorCache" /var/lib/mirrorcache


### PR DESCRIPTION
Based on:
- [users and groups packaging guidelines](https://en.opensuse.org/openSUSE:Packaging_guidelines#Users_and_Groups)
- [systemd packaging guidelines](https://en.opensuse.org/openSUSE:Systemd_packaging_guidelines#Creating_files_and_subdirectories_in_.2Fvar.2Frun_and_.2Frun)