### PR TITLE
Schedule scan when main server serves as a mirror

### DIFF
--- a/lib/MirrorCache/WebAPI/Plugin/Dir.pm
+++ b/lib/MirrorCache/WebAPI/Plugin/Dir.pm
@@ -242,7 +242,11 @@ sub _guess_what_to_render {
     my $tx   = $c->render_later->tx;
     my ($path, $trailing_slash) = $dm->path;
 
-    return $root->render_file($c, $path) if $dm->metalink;
+    if ($dm->metalink) {
+        my $res = $root->render_file($c, $path);
+        $c->mmdb->emit_miss($path, $dm->country);
+        return $res;
+    }
 
     my $rootlocation = $root->location($c);
     my $url  = $rootlocation . $path;

--- a/lib/MirrorCache/WebAPI/Plugin/RenderFileFromMirror.pm
+++ b/lib/MirrorCache/WebAPI/Plugin/RenderFileFromMirror.pm
@@ -229,7 +229,7 @@ sub _build_metalink() {
                 my $url = $m->{url};
                 my $colon = index(substr($url,0,6), ':');
                 next unless $colon > 0;
-                if (!$root_included && $country ne $m->{country} && $dm->root_is_better($m->{region}, $m->{lng})) {
+                if (!$root_included && $country ne uc($m->{country}) && $dm->root_is_better($m->{region}, $m->{lng})) {
                     $root_included = 1;
                     $print_root->();
                 }

--- a/t/environ/06-remote-geo-root-country-same-region.sh
+++ b/t/environ/06-remote-geo-root-country-same-region.sh
@@ -41,3 +41,17 @@ $mc/curl --interface 127.0.0.4 -I '/download/folder1/file1.dat?REGION=eu' | grep
 # check order of the same in metalink file
 $mc/curl --interface 127.0.0.2 '/download/folder1/file1.dat.metalink?REGION=eu' | grep -A1 $DE_ADDRESS | grep $CZ_ADDRESS
 $mc/curl --interface 127.0.0.4 '/download/folder1/file1.dat.metalink?REGION=eu' | grep -A1 $CZ_ADDRESS | grep $DE_ADDRESS
+
+#########################################
+echo test scan is scheduled when metadata is missing
+$mc/curl -Is --interface 127.0.0.3 '/download/folder2/file1.dat.metalink?COUNTRY=de' | grep -A1 $DE_ADDRESS
+$mc/backstage/job folder_sync_schedule_from_misses
+$mc/backstage/job folder_sync_schedule
+# $mc/backstage/job mirror_scan_schedule_from_misses
+$mc/backstage/shoot
+$mc/curl -is --interface 127.0.0.3 '/download/folder2/file1.dat.metalink?COUNTRY=de' | grep -A1 $DE_ADDRESS | grep $CZ_ADDRESS
+$mc/curl -is --interface 127.0.0.3 '/download/folder2/file1.dat.metalink?COUNTRY=cz' | grep -A1 $CZ_ADDRESS | grep $DE_ADDRESS
+#########################################
+
+
+


### PR DESCRIPTION
In situation when:
- metadata is requested;
- there is no mirror;
- MIRRORCACHE_ROOT_COUNTRY=1;
the path_miss was not scheduled so the scan did not happen.