### PR TITLE
Schedule jobs from stat

### DIFF
--- a/lib/MirrorCache/Datamodule.pm
+++ b/lib/MirrorCache/Datamodule.pm
@@ -33,6 +33,7 @@ has '_original_path';
 has '_agent';
 has [ '_is_secure', '_is_ipv4', '_is_head' ];
 has 'mirrorlist';
+has [ 'folder_id', 'file_id' ]; # shortcut to requested folder and file, if known
 
 has root_country => ($ENV{MIRRORCACHE_ROOT_COUNTRY} ? lc($ENV{MIRRORCACHE_ROOT_COUNTRY}) : "");
 has '_root_region';
@@ -310,7 +311,7 @@ sub _init_path($self) {
 }
 
 sub root_is_hit($self) {
-    return 1 if $self->_root_region eq $self->region;
+    return 1 if $self->_root_region && $self->_root_region eq $self->region;
     return 0;
 }
 

--- a/lib/MirrorCache/Schema/ResultSet/AuditEvent.pm
+++ b/lib/MirrorCache/Schema/ResultSet/AuditEvent.pm
@@ -25,88 +25,18 @@ use Time::ParseDate;
 use base 'DBIx::Class::ResultSet';
 use Mojo::JSON qw/decode_json/;
 
-sub path_misses {
+sub mirror_path_errors {
     my ($self, $prev_event_log_id, $limit) = @_;
 
     my $rsource = $self->result_source;
     my $schema  = $rsource->schema;
     my $dbh     = $schema->storage->dbh;
 
-    my $sql = "select id, event_data from audit_event where name='path_miss'";
+    my $sql = "select id, event_data from audit_event where name='mirror_path_error'";
     $sql = "$sql and id > $prev_event_log_id" if $prev_event_log_id;
     $sql = "$sql union all select max(id), '-max_id' from audit_event";
     $sql = "$sql order by id desc";
     $sql = "$sql limit ($limit+1)" if $limit;
-
-    my $prep = $dbh->prepare($sql);
-    $prep->execute();
-    my $arrayref = $dbh->selectall_arrayref($prep, { Slice => {} });
-    my $id;
-    my %path_country = ();
-    my %countries = ();
-    my %seen  = ();
-    foreach my $miss ( @$arrayref ) {
-        my $event_data = $miss->{event_data};
-        next if $seen{$event_data};
-        $id = $miss->{id} unless $id;
-        next if $event_data eq '-max_id';
-        $seen{$event_data} = 1;
-        my $data = decode_json($event_data);
-        my $path = $data->{path};
-        next unless $path;
-        my $country = $data->{country};
-        my $rec = $path_country{$path};
-        $rec = {} unless $rec;
-        if ($country) {
-            $rec->{$country} = 1;
-            $countries{$country} = 1 ;
-        }
-        $path_country{$path} = $rec;
-    }
-    my @country_list = (keys %countries);
-    return ($id, \%path_country, \@country_list);
-}
-
-sub mirror_probe_errors {
-    my ($self, $prev_event_log_id, $limit) = @_;
-
-    my $rsource = $self->result_source;
-    my $schema  = $rsource->schema;
-    my $dbh     = $schema->storage->dbh;
-
-    my $sql = "select id, event_data from audit_event where name='mirror_probe_error'";
-    $sql = "$sql and id > $prev_event_log_id" if $prev_event_log_id;
-    $sql = "$sql order by id desc";
-    $sql = "$sql limit ($limit)" if $limit;
-
-    my $prep = $dbh->prepare($sql);
-    $prep->execute();
-    my $arrayref = $dbh->selectall_arrayref($prep, { Slice => {} });
-    my $id;
-    my @paths = ();
-    my %seen  = ();
-    foreach my $miss ( @$arrayref ) {
-        my $event_data = $miss->{event_data};
-        next if $seen{$event_data};
-        $id = $miss->{id} unless $id;
-        $seen{$event_data} = 1;
-        push @paths, from_json($event_data);
-    }
-    return ($id, \@paths);
-}
-
-sub mirror_misses {
-    my ($self, $prev_event_log_id, $limit) = @_;
-
-    my $rsource = $self->result_source;
-    my $schema  = $rsource->schema;
-    my $dbh     = $schema->storage->dbh;
-
-    my $sql = "select id, event_data from audit_event where name = 'mirror_miss'";
-    $sql = "$sql and id > $prev_event_log_id" if $prev_event_log_id;
-    $sql = "$sql union all select max(id), '-max_id' from audit_event";
-    $sql = "$sql order by id desc";
-    $sql = "$sql limit ($limit)" if $limit;
 
     my $prep = $dbh->prepare($sql);
     $prep->execute();

--- a/lib/MirrorCache/Schema/ResultSet/AuditEvent.pm
+++ b/lib/MirrorCache/Schema/ResultSet/AuditEvent.pm
@@ -32,7 +32,7 @@ sub mirror_path_errors {
     my $schema  = $rsource->schema;
     my $dbh     = $schema->storage->dbh;
 
-    my $sql = "select id, event_data from audit_event where name='mirror_path_error'";
+    my $sql = "select id, event_data from audit_event where name in ('mirror_path_error', 'mirror_country_miss')";
     $sql = "$sql and id > $prev_event_log_id" if $prev_event_log_id;
     $sql = "$sql union all select max(id), '-max_id' from audit_event";
     $sql = "$sql order by id desc";

--- a/lib/MirrorCache/Task/FolderSync.pm
+++ b/lib/MirrorCache/Task/FolderSync.pm
@@ -161,7 +161,7 @@ sub _sync {
 
     $folder->update({db_sync_last => datetime_now()});
     $job->note(updated => $path, count => $cnt, deleted => $deleted, updated => $updated);
-    if ($cnt) {
+    if ($cnt || $updated) {
         $minion->enqueue('mirror_scan_demand' => [$path] => {priority => 7} );
         $minion->enqueue('folder_hashes_create' => [$path] => {queue => $HASHES_QUEUE}) if $HASHES_COLLECT && $app->backstage->estimate_inactive_jobs('folder_hashes_create', $HASHES_QUEUE) < 1000;
     }

--- a/lib/MirrorCache/Task/MirrorScanScheduleFromMisses.pm
+++ b/lib/MirrorCache/Task/MirrorScanScheduleFromMisses.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 SUSE LLC
+# Copyright (C) 2020,2021 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,6 +15,7 @@
 
 package MirrorCache::Task::MirrorScanScheduleFromMisses;
 use Mojo::Base 'Mojolicious::Plugin';
+use Mojo::File qw(path);
 
 sub register {
     my ($self, $app) = @_;
@@ -25,28 +26,28 @@ my $DELAY   = int($ENV{MIRRORCACHE_SCHEDULE_RETRY_INTERVAL} // 5);
 my $TIMEOUT = int($ENV{MIRRORCACHE_COUNTRY_RESCAN_TIMEOUT} // 120);
 
 sub _run {
-    my ($app, $job, $prev_event_log_id) = @_;
+    my ($app, $job, $prev_stat_id) = @_;
     my $job_id = $job->id;
     my $pref = "[scan_from_misses $job_id]";
-    my $id_in_notes = $job->info->{notes}{event_log_id};
-    $prev_event_log_id = $id_in_notes if $id_in_notes;
+    my $id_in_notes = $job->info->{notes}{stat_id};
+    $prev_stat_id = $id_in_notes if $id_in_notes;
     print(STDERR "$pref read id from notes: $id_in_notes\n") if $id_in_notes;
-    print(STDERR "$pref use id from param: $prev_event_log_id\n") if $prev_event_log_id && (!$id_in_notes || $prev_event_log_id != $id_in_notes);
+    print(STDERR "$pref use id from param: $prev_stat_id\n") if $prev_stat_id && (!$id_in_notes || $prev_stat_id != $id_in_notes);
 
     my $minion = $app->minion;
     # prevent multiple scheduling tasks to run in parallel
     return $job->finish('Previous job is still active')
-      unless my $guard = $minion->guard('mirror_scan_schedule_from_misses', 86400);
+      unless my $guard = $minion->guard('mirror_scan_schedule_from_misses', 60);
 
     my $schema = $app->schema;
-    my $limit = 1000;
+    my $limit = $prev_stat_id ? 1000 : 10;
 
-    my ($event_log_id, $path_country_map, $country_list) = $schema->resultset('AuditEvent')->mirror_misses($prev_event_log_id, $limit);
+    my ($stat_id, $path_country_map, $country_list) = $schema->resultset('Stat')->mirror_misses($prev_stat_id, $limit);
     my $last_run = 0;
     while (scalar(%$path_country_map)) {
         my $cnt = 0;
-        $prev_event_log_id = $event_log_id;
-        print(STDERR "$pref read id from event log up to: $event_log_id\n");
+        $prev_stat_id = $stat_id;
+        print(STDERR "$pref read id from stat up to: $stat_id\n");
         for my $path (sort keys %$path_country_map) {
             my $countries = $path_country_map->{$path};
             next unless $countries && keys %$countries;
@@ -66,14 +67,15 @@ sub _run {
             $cnt = $cnt + 1;
         }
         for my $country (@$country_list) {
-            next unless $minion->lock('mirror_probe_scheduled_' . $country, 60); # don't schedule if schedule hapened in last 60 sec
+            next unless $minion->lock('mirror_probe_scheduled_' . $country, 60); # don't schedule if schedule happened in last 60 sec
             next unless $minion->lock('mirror_probe_incomplete_for_' . $country, 6000); # don't schedule until probe job completed
             $minion->unlock('mirror_force_done');
             $minion->enqueue('mirror_probe' => [$country] => {priority => 6});
         }
         $last_run = $last_run + $cnt;
         last unless $cnt;
-        ($event_log_id, $path_country_map, $country_list) = $schema->resultset('AuditEvent')->mirror_misses($prev_event_log_id, $limit);
+        $limit = 1000;
+        ($stat_id, $path_country_map, $country_list) = $schema->resultset('Stat')->mirror_misses($prev_stat_id, $limit);
     }
 
     if ($minion->lock('mirror_force_done', 9000)) {
@@ -86,11 +88,11 @@ sub _run {
         }
     }
 
-    $prev_event_log_id = 0 unless $prev_event_log_id;
-    print(STDERR "$pref will retry with id: $prev_event_log_id\n");
+    $prev_stat_id = 0 unless $prev_stat_id;
+    print(STDERR "$pref will retry with id: $prev_stat_id\n");
     my $total = $job->info->{notes}{total};
     $total = 0 unless $total;
-    $job->note(event_log_id => $prev_event_log_id, total => $total, last_run => $last_run);
+    $job->note(stat_id => $prev_stat_id, total => $total, last_run => $last_run);
     return $job->retry({delay => $DELAY});
 }
 

--- a/lib/MirrorCache/WebAPI/Plugin/AuditLog.pm
+++ b/lib/MirrorCache/WebAPI/Plugin/AuditLog.pm
@@ -24,7 +24,8 @@ use MirrorCache::Events;
 # mirror_scan_error means we were not able to find the file on the mirror, and we don't know if it ever existed
 # mirror_path_error means we know that the file did exist on the mirror, but are not able to access it anymore, getting a valid HTML response code
 # mirror_error means there was an error while trying to HEAD a file on a mirror (without valid HTML response)
-my @error_events = qw(mirror_scan_error mirror_path_error mirror_error);
+# mirror_country_miss means that request was served by a mirror in region
+my @error_events = qw(mirror_scan_error mirror_path_error mirror_error mirror_country_miss);
 my @other_events = qw(unknown_ip debug);
 my @user_events = qw(user_update user_delete server_create server_update server_delete);
 

--- a/lib/MirrorCache/WebAPI/Plugin/AuditLog.pm
+++ b/lib/MirrorCache/WebAPI/Plugin/AuditLog.pm
@@ -20,8 +20,6 @@ use Mojo::IOLoop;
 use Mojo::JSON 'to_json';
 use MirrorCache::Events;
 
-my @path_events = qw(path_miss path_hit path_scan_complete);
-my @mirror_events = qw(mirror_pick mirror_miss mirror_scan_complete);
 # reasons for mirror_scan_error and mirror_path_error and mirror_error are similar
 # mirror_scan_error means we were not able to find the file on the mirror, and we don't know if it ever existed
 # mirror_path_error means we know that the file did exist on the mirror, but are not able to access it anymore, getting a valid HTML response code
@@ -35,7 +33,7 @@ sub register {
 
     # register for events
     my @events = (
-        @path_events, @mirror_events, @error_events, @other_events, @user_events
+        @error_events, @other_events, @user_events
     );
     for my $e (@events) {
         MirrorCache::Events->singleton->on("mc_$e" => sub { shift; $self->on_event($app, @_) });
@@ -55,7 +53,7 @@ sub on_event {
         $tag = $event_data->{tag};
         delete($event_data->{tag});
     }
-    
+
     # no need to log mc_ prefix in mc log
     $event =~ s/^mc_//;
     $app->schema->resultset('AuditEvent')->create({

--- a/lib/MirrorCache/WebAPI/Plugin/Backstage.pm
+++ b/lib/MirrorCache/WebAPI/Plugin/Backstage.pm
@@ -32,7 +32,7 @@ sub new {
 }
 
 my @permanent_jobs =
-  qw(folder_sync_schedule_from_misses folder_sync_schedule mirror_scan_schedule_from_misses cleanup stat_agg_schedule mirror_check_from_stat);
+  qw(folder_sync_schedule_from_misses folder_sync_schedule mirror_scan_schedule_from_misses mirror_scan_schedule_from_path_errors cleanup stat_agg_schedule mirror_check_from_stat);
 
 sub register_tasks {
     my $self = shift;

--- a/lib/MirrorCache/WebAPI/Plugin/Mmdb.pm
+++ b/lib/MirrorCache/WebAPI/Plugin/Mmdb.pm
@@ -58,16 +58,6 @@ sub register {
         return undef;
     });
 
-    # move it to Datamodule?
-    $app->helper( 'mmdb.emit_miss' => sub {
-        my ($c, $path, $country) = @_;
-        if ($country) {
-            $c->emit_event('mc_path_miss', { path => $path, country => $country } );
-        } else {
-            $c->emit_event('mc_path_miss', { path => $path } );
-        }
-    });
-
     if ($reader) {
         $app->plugin('ClientIP');
         $app->helper( 'mmdb.client_ip' => sub { return shift->client_ip; } );

--- a/lib/MirrorCache/WebAPI/Plugin/RenderFileFromMirror.pm
+++ b/lib/MirrorCache/WebAPI/Plugin/RenderFileFromMirror.pm
@@ -32,7 +32,6 @@ sub register {
 
     $app->helper( 'mirrorcache.render_file' => sub {
         my ($c, $filepath, $dm)= @_;
-        $c->emit_event('mc_dispatch', $filepath);
         my $root = $c->mc->root;
         my $f = Mojo::File->new($filepath);
         my $dirname  = $f->dirname;
@@ -52,14 +51,15 @@ sub register {
                 return $root->render_file($dm, $filepath, 1);
             }
         }
-
+        
         my $folder = $c->schema->resultset('Folder')->find({path => $dirname});
+        $dm->folder_id($folder->id) if $folder;
         my $file = $c->schema->resultset('File')->find_with_hash($folder->id, $basename) if $folder;
+        $dm->file_id($file->{id}) if $file;
         my $country = $dm->country;
         my $region  = $dm->region;
         # render from root if we cannot determine country when GeoIP is enabled or unknown file
         if ((!$country && $ENV{MIRRORCACHE_CITY_MMDB}) || !$folder || !$file) {
-            $c->mmdb->emit_miss($dirname, $country) unless $file;
             return $root->render_file($dm, $filepath . '.metalink')  if ($dm->metalink && !$file); # file is unknown - cannot generate metalink
             return $root->render_file($dm, $filepath)
               unless $dm->metalink # TODO we still can check file on mirrors even if it is missing in DB
@@ -111,10 +111,8 @@ sub register {
         if ($dm->metalink || $dm->mirrorlist) {
             if ($mirror) {
                 $c->stat->redirect_to_mirror($mirror->{mirror_id}, $dm);
-                $c->emit_event('mc_mirror_miss', {path => $dirname, country => $country}) if $country && $country ne $mirror->{country};
             } else {
                 $c->stat->redirect_to_root($dm, 0);
-                $c->emit_event('mc_mirror_miss', {path => $dirname, country => $country}) if $country;
             }
         }
 
@@ -190,7 +188,6 @@ sub register {
             return 1;
         }
         unless ($mirror) {
-            $c->emit_event('mc_mirror_miss', {path => $dirname, country => $country}) if $country;
             $root->render_file($dm, $filepath, $dm->root_is_hit);
             return 1;
         }
@@ -205,7 +202,6 @@ sub register {
             $c->redirect_to($url);
             eval {
                 $c->stat->redirect_to_mirror($mirror->{mirror_id}, $dm);
-                $c->emit_event('mc_mirror_miss', {path => $dirname, country => $country}) if $country && $country ne $mirror->{country};
             };
             return 1;
         }
@@ -229,7 +225,6 @@ sub register {
                 $mirror = shift @$mirrors_rest;
             }
             unless ($mirror) {
-                $c->emit_event('mc_mirror_miss', {path => $dirname, country => $country});
                 return $root->render_file($dm, $filepath);
             }
             # Check below is needed only when MIRRORCACHE_ROOT_COUNTRY is set
@@ -246,15 +241,14 @@ sub register {
                     my $size = $result->headers->content_length if $result->headers;
                     if ($size && $expected_size && $size ne $expected_size) {
                         $code = 409;
+                        $c->emit_event('mc_mirror_path_error', {path => $dirname, code => $code, url => $url, folder => $folder->id, country => $dm->country});
                         return undef;
                     }
                     $c->redirect_to($url);
-                    $c->emit_event('mc_path_hit', {path => $dirname, mirror => $url});
-                    $c->emit_event('mc_mirror_miss', {path => $dirname, country => $country}) if $country && $country ne $mirror->{country};
                     $c->stat->redirect_to_mirror($mirror->{mirror_id}, $dm);
                     return 1;
                 }
-                $c->emit_event('mc_mirror_path_error', {path => $dirname, code => $code, url => $url, server => $mirror->{id}, folder => $folder->id});
+                $c->emit_event('mc_mirror_path_error', {path => $dirname, code => $code, url => $url, folder => $folder->id, country => $dm->country});
             })->catch(sub {
                 $c->emit_event('mc_mirror_error', {path => $dirname, error => shift, url => $url, server => $mirror->{id}, folder => $folder->id});
             })->finally(sub {

--- a/lib/MirrorCache/WebAPI/Plugin/RootLocal.pm
+++ b/lib/MirrorCache/WebAPI/Plugin/RootLocal.pm
@@ -52,8 +52,11 @@ sub is_dir {
 }
 
 sub render_file {
-    my ($self, $dm, $filepath) = @_;
-    return !!$dm->c->reply->static($filepath);
+    my ($self, $dm, $filepath, $not_miss) = @_;
+    my $c = $dm->c;
+    my $res = !!$c->reply->static($filepath);
+    $c->stat->redirect_to_root($dm, $not_miss);
+    return $res;
 }
 
 sub foreach_filename {

--- a/lib/MirrorCache/WebAPI/Plugin/Stat.pm
+++ b/lib/MirrorCache/WebAPI/Plugin/Stat.pm
@@ -63,7 +63,7 @@ sub redirect_to_mirror($self, $mirror_id, $dm) {
     return undef if $mirror_id == -1 && 'media' eq substr($path, -length('media'));
     my $rows = $self->rows;
     my @rows = defined $rows? @$rows : ();
-    push @rows, [ sha1_hex($dm->ip), scalar $dm->agent, scalar ($path . $trailing_slash), $dm->country, datetime_now(), $mirror_id, $dm->is_secure, $dm->is_ipv4, $dm->metalink? 1 : 0, $dm->is_head ];
+    push @rows, [ sha1_hex($dm->ip), scalar $dm->agent, scalar ($path . $trailing_slash), $dm->country, datetime_now(), $mirror_id, $dm->folder_id, $dm->file_id, $dm->is_secure, $dm->is_ipv4, $dm->metalink? 1 : 0, $dm->is_head ];
     my $cnt = @rows;
     if ($cnt >= $FLUSH_COUNT) {
         $self->rows(undef);
@@ -86,8 +86,8 @@ sub flush($self, $rows) {
     $self->rows(undef);
     my @rows = @$rows;
     my $sql = <<'END_SQL';
-insert into stat(ip_sha1, agent, path, country, dt, mirror_id, secure, ipv4, metalink, head)
-values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+insert into stat(ip_sha1, agent, path, country, dt, mirror_id, folder_id, file_id, secure, ipv4, metalink, head)
+values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 END_SQL
 
     eval {

--- a/lib/MirrorCache/resources/migrations/pg.sql
+++ b/lib/MirrorCache/resources/migrations/pg.sql
@@ -140,6 +140,8 @@ create table if not exists stat (
     country char(2),
     dt timestamp NOT NULL,
     mirror_id int,
+    folder_id bigint,
+    file_id bigint,
     secure boolean NOT NULL,
     ipv4 boolean NOT NULL,
     metalink boolean default 'f',
@@ -187,3 +189,6 @@ create index hash_file_id_size on hash(file_id, size);
 create index hash_sha256 on hash(sha256);
 -- 5 up
 create index audit_event_dt on audit_event(dt, name);
+-- 6 up
+alter table stat add column if not exists folder_id bigint, add column if not exists file_id bigint;
+create index if not exists stat_id_mirror_folder on stat(id, mirror_id, folder_id);

--- a/t/environ/01-smoke-plan-scan.sh
+++ b/t/environ/01-smoke-plan-scan.sh
@@ -4,7 +4,7 @@ set -exo pipefail
 mc=$(environ mc $(pwd))
 
 MIRRORCACHE_COUNTRY_RESCAN_TIMEOUT=3
-$mc/gen_env MIRRORCACHE_PERMANENT_JOBS="'folder_sync_schedule_from_misses folder_sync_schedule mirror_scan_schedule_from_misses'" \
+$mc/gen_env MIRRORCACHE_PERMANENT_JOBS="'folder_sync_schedule_from_misses folder_sync_schedule mirror_scan_schedule_from_misses mirror_scan_schedule_from_path_errors'" \
         MIRRORCACHE_SCHEDULE_RETRY_INTERVAL=1 \
         MIRRORCACHE_COUNTRY_RESCAN_TIMEOUT=$MIRRORCACHE_COUNTRY_RESCAN_TIMEOUT
 
@@ -41,9 +41,6 @@ $mc/backstage/shoot
 $mc/db/sql "select * from minion_locks"
 # MIRRORCACHE_MIRROR_RESCAN_TIMEOUT hasn't passed yet, so no scanning job should occur
 test 1 == $($mc/db/sql "select count(*) from minion_jobs where task = 'mirror_scan' and args::varchar like '%/folder1%mx%'")
-
-# TODO decide strategy re-scanning country when a mirror from region was picked
-exit 0
 
 sleep $MIRRORCACHE_COUNTRY_RESCAN_TIMEOUT
 sleep $MIRRORCACHE_COUNTRY_RESCAN_TIMEOUT

--- a/t/environ/01-smoke-plan-scan.sh
+++ b/t/environ/01-smoke-plan-scan.sh
@@ -42,6 +42,9 @@ $mc/db/sql "select * from minion_locks"
 # MIRRORCACHE_MIRROR_RESCAN_TIMEOUT hasn't passed yet, so no scanning job should occur
 test 1 == $($mc/db/sql "select count(*) from minion_jobs where task = 'mirror_scan' and args::varchar like '%/folder1%mx%'")
 
+# TODO decide strategy re-scanning country when a mirror from region was picked
+exit 0
+
 sleep $MIRRORCACHE_COUNTRY_RESCAN_TIMEOUT
 sleep $MIRRORCACHE_COUNTRY_RESCAN_TIMEOUT
 

--- a/t/environ/01-smoke.sh
+++ b/t/environ/01-smoke.sh
@@ -26,6 +26,9 @@ $mc/db/sql "insert into server(hostname,urldir,enabled,country,region) select '$
 
 $mc/curl -Is /download/folder1/file1.dat
 
+$mc/sql "select * from stat"
+$mc/sql_test 1 == "select count(*) from stat"
+
 $mc/backstage/job folder_sync_schedule_from_misses
 $mc/backstage/job folder_sync_schedule
 $mc/backstage/shoot

--- a/t/environ/02-files.sh
+++ b/t/environ/02-files.sh
@@ -73,17 +73,16 @@ $mc/backstage/shoot
 
 test 4 == $($mc/db/sql "select count(*) from folder_diff_server")
 
-cnt="$($mc/db/sql "select count(*) from audit_event")"
+cnt="$($mc/db/sql "select max(id) from stat")"
 
 $mc/curl -I /download/folder1/file2.dat | grep 302
 
 # it shouldn't try to reach file on mirrors yet, because scanner didn't find files
-test 0 == $($mc/db/sql "select count(*) from audit_event where name like 'mirror_miss' and id > $cnt")
-
+test 0 == $($mc/db/sql "select count(*) from stat where mirror_id = -1 and file_id is not NULL and id > $cnt")
 
 $mc/curl -I /download/folder2/file4.dat | grep 200
 # now an error must be logged
-test 1 == $($mc/db/sql "select count(*) from audit_event where name like 'mirror_miss' and id > $cnt")
+test 1 == $($mc/db/sql "select count(*) from stat where mirror_id = -1 and file_id is not NULL and id > $cnt")
 
 ##################################
 # let's test path distortions

--- a/t/environ/04-remote-nginx-redirect.sh
+++ b/t/environ/04-remote-nginx-redirect.sh
@@ -47,7 +47,7 @@ mv $ng7/dt/folder1/file2.dat $ng8/dt/folder1/
 # gets redirected to MIRRORCACHE_REDIRECT again
 $mc/curl -I /download/folder1/file2.dat | grep $($ap9/print_address)
 
-$mc/backstage/job mirror_scan_schedule_from_misses
+$mc/backstage/job mirror_scan_schedule_from_path_errors
 $mc/backstage/shoot
 
 $mc/curl -H "Accept: */*, application/metalink+xml" /download/folder1/file2.dat | grep $($ap9/print_address)

--- a/t/environ/04-remote-nginx.sh
+++ b/t/environ/04-remote-nginx.sh
@@ -39,7 +39,6 @@ $mc/db/sql "select * from file"
 test 0  == $($mc/db/sql "select size from file where name='file1.dat'")
 test 10 == $($mc/db/sql "select size from file where name='file2.dat'")
 
-
 test 2 == $($mc/db/sql "select count(*) from folder_diff")
 test 1 == $($mc/db/sql "select count(*) from folder_diff_file")
 
@@ -50,7 +49,7 @@ mv $ng7/dt/folder1/file2.dat $ng8/dt/folder1/
 # gets redirected to root again
 $mc/curl -I /download/folder1/file2.dat | grep $($ng9/print_address)
 
-$mc/backstage/job mirror_scan_schedule_from_misses
+$mc/backstage/job mirror_scan_schedule_from_path_errors
 $mc/backstage/shoot
 
 $mc/curl -H "Accept: */*, application/metalink+xml" /download/folder1/file2.dat | grep $($ng9/print_address)

--- a/t/environ/04-remote.sh
+++ b/t/environ/04-remote.sh
@@ -45,7 +45,7 @@ mv $ap7/dt/folder1/file2.dat $ap8/dt/folder1/
 # gets redirected to root again
 $mc/curl -I /download/folder1/file2.dat | grep $($ap9/print_address)
 
-$mc/backstage/job mirror_scan_schedule_from_misses
+$mc/backstage/job mirror_scan_schedule_from_path_errors
 $mc/backstage/shoot
 
 $mc/curl -H "Accept: */*, application/metalink+xml" /download/folder1/file2.dat | grep $($ap9/print_address)

--- a/t/environ/04-rsync.sh
+++ b/t/environ/04-rsync.sh
@@ -56,7 +56,7 @@ echo -n 123456789 > $rs/dt/folder1/file2.dat
 # gets redirected to root again
 $mc/curl -I /download/folder1/file2.dat | grep fake.com
 
-# call incorrect file to force new size sync sync
+# call incorrect file to force new sync
 $mc/curl /download/folder1/incorrect
 $mc/backstage/job folder_sync_schedule_from_misses
 $mc/backstage/job folder_sync_schedule
@@ -105,12 +105,12 @@ $mc/backstage/shoot
 
 test 2 == $($mc/db/sql "select count(*) from folder_diff_server")
 
-cnt="$($mc/db/sql 'select count(*) from audit_event')"
+cnt="$($mc/db/sql 'select max(id) from audit_event')"
 
 $mc/curl -I /download/folder1/file4.dat
 
 # it shouldn't try to probe yet, because scanner didn't find files on the mirrors
-test 0 == $($mc/db/sql "select count(*) from audit_event where name = 'mirror_probe' and id > $cnt")
+$mc/sql_test 0 == "select count(*) from audit_event where name = 'mirror_path_error' and id > $cnt"
 
 for x in $rs $ap7 $ap8; do
     mkdir $x/dt/folder1/folder11

--- a/t/environ/06-remote-geo-dynamic.sh
+++ b/t/environ/06-remote-geo-dynamic.sh
@@ -10,7 +10,8 @@ ap6=$(environ ap6)
 
 $mc/gen_env MIRRORCACHE_ROOT=http://$($ap6/print_address) \
     MIRRORCACHE_STAT_FLUSH_COUNT=1 \
-    MIRRORCACHE_SCHEDULE_RETRY_INTERVAL=3
+    MIRRORCACHE_SCHEDULE_RETRY_INTERVAL=3 \
+    MIRRORCACHE_COUNTRY_RESCAN_TIMEOUT=0
 
 for x in $ap6 $ap7 $ap8 $ap9; do
     mkdir -p $x/dt/{folder1,folder2,folder3}
@@ -37,6 +38,7 @@ test 0 == "$(grep -c Poll $mc/.cerr)"
 
 sleep 10
 job_id=$($mc/backstage/job -e mirror_scan -a '["/folder1","cn"]')
+sleep 1
 
 # check redirects to headquarter are logged properly
 $mc/db/sql "select * from stat"

--- a/t/lib/environ/mc/source/gen_env.sh.m4
+++ b/t/lib/environ/mc/source/gen_env.sh.m4
@@ -8,6 +8,7 @@ export MIRRORCACHE_CITY_MMDB=__srcdir/t/data/city.mmdb
 export MOJO_LISTEN=http://*:__port
 export MIRRORCACHE_AUTH_URL=''
 export MIRRORCACHE_PERMANENT_JOBS=''
+export MIRRORCACHE_STAT_FLUSH_COUNT=1
 "
 
     for i in "$@"; do

--- a/t/lib/environ/mc/source/sql.sh.m4
+++ b/t/lib/environ/mc/source/sql.sh.m4
@@ -1,0 +1,1 @@
+__workdir/db/sql "$@"

--- a/t/lib/environ/mc/source/sql_test.sh.m4
+++ b/t/lib/environ/mc/source/sql_test.sh.m4
@@ -1,0 +1,3 @@
+set -e
+res=$(__workdir/db/sql "$3")
+test $1 $2 $res || ( echo FAILED: $1 $2 $res ; exit 1 )


### PR DESCRIPTION
Historically table audit_event was used to schedule jobs
Since stat table was introduced to show similar info, it is more convenient to use it for scheduling.
Events for miss and hit are not logged anymore.
New columns folder_id and file_id are added to stat table, they are used to distinguish path_miss vs mirror_miss.