### PR TITLE
Fix redirect to https when mirror doesnt have it

### DIFF
--- a/lib/MirrorCache/WebAPI/Plugin/RenderFileFromMirror.pm
+++ b/lib/MirrorCache/WebAPI/Plugin/RenderFileFromMirror.pm
@@ -196,7 +196,7 @@ sub register {
             return 1;
         }
 
-        unless ($dm->pedantic) {
+        unless ($dm->pedantic || index($filepath, '-Current') > 0) {
             # Check below is needed only when MIRRORCACHE_ROOT_COUNTRY is set
             # only with remote root and when no mirrors should be used for the root's country
             if ($country ne $mirror->{country} && $dm->root_is_better($mirror->{region}, $mirror->{lng})) {


### PR DESCRIPTION
Previously such mirrors were just given lower priority.
We still show them in mirrorlist still, just with http