### PR TITLE
Import file metadata from a headquarter instance to a subsidiary instance

### DIFF
--- a/lib/MirrorCache/Task/FolderHashesImport.pm
+++ b/lib/MirrorCache/Task/FolderHashesImport.pm
@@ -1,0 +1,80 @@
+# Copyright (C) 2021 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package MirrorCache::Task::FolderHashesImport;
+use Mojo::Base 'Mojolicious::Plugin';
+use Mojo::UserAgent;
+
+sub register {
+    my ($self, $app) = @_;
+    $app->minion->add_task(folder_hashes_import => sub { _run($app, @_) });
+}
+
+sub _run {
+    my ($app, $job, $path) = @_;
+    return $job->fail('Empty path is not allowed') unless $path;
+    return $job->fail('Trailing slash is not allowed') if '/' eq substr($path, -1) && $path ne '/';
+    return $job->fail('MIRRORCACHE_HEADQUARTER is not set') unless $ENV{MIRRORCACHE_HEADQUARTER};
+
+    my $minion = $app->minion;
+    return $job->finish('Previous folder hashes import job is still active')
+      unless my $guard = $minion->guard('folder_hashes_import' . $path, 360);
+
+    my $schema = $app->schema;
+    my $root   = $app->mc->root;
+    $job->note($path => 1);
+
+    my $folder = $schema->resultset('Folder')->find({path => $path});
+    return $job->finish("not found") unless $folder;
+
+    my $folder_id = $folder->id;
+    my $count     = 0;
+    my $errcount  = 0;
+
+    my $max_dt = $schema->resultset('Hash')->hashes_max_dt($folder_id);
+    $max_dt = $max_dt ? "&since=$max_dt" : '';
+
+    my $hq_url = $ENV{MIRRORCACHE_HEADQUARTER} . $path . '?hashes' . $max_dt;
+    $hq_url = "http://" . $hq_url unless 'http' eq substr($hq_url, 0, 4);
+
+    my $mojo_url = Mojo::URL->new($hq_url);
+    my $res      = Mojo::UserAgent->new->get($mojo_url)->result;
+    return $job->fail('Request to HEADQUARTER ' . $hq_url . ' failed, response code ' . $res->code)
+      if $res->code != 200;
+
+    my $res_json = $res->json;
+
+    for my $hash (@$res_json) {
+        my $basename = $hash->{name};
+        next unless $basename;
+        my $file = $schema->resultset('File')->find({folder_id => $folder_id, name => $basename});
+        next unless $file;
+        eval {
+            $schema->resultset('Hash')->store($file->id, $hash->{mtime}, $hash->{size}, $hash->{md5},
+                $hash->{sha1}, $hash->{sha256}, $hash->{piece_size}, $hash->{pieces});
+            $count++;
+        };
+        if ($@) {
+            my $err = $@;
+            $app->log->warn("Error while storing hash data for file $path/$basename:");
+            $app->log->warn($err);
+            $errcount++;
+        }
+    }
+
+    $job->note(count => $count, errors => $errcount);
+}
+
+1;

--- a/lib/MirrorCache/WebAPI/Plugin/Backstage.pm
+++ b/lib/MirrorCache/WebAPI/Plugin/Backstage.pm
@@ -48,6 +48,7 @@ sub register_tasks {
         qw(MirrorCache::Task::MirrorLocation),
         qw(MirrorCache::Task::MirrorProbe),
         qw(MirrorCache::Task::FolderHashesCreate),
+        qw(MirrorCache::Task::FolderHashesImport),
         qw(MirrorCache::Task::FolderSyncScheduleFromMisses),
         qw(MirrorCache::Task::FolderSyncSchedule),
         qw(MirrorCache::Task::FolderSync),

--- a/t/environ/02-files-hashes-import.sh
+++ b/t/environ/02-files-hashes-import.sh
@@ -1,0 +1,61 @@
+#!lib/test-in-container-environ.sh
+set -ex
+
+# mc environ by number:
+# 9 - headquarter
+# 6 - NA subsidiary
+
+# hq mirros: ap1 ap2
+# na mirros: ap3 ap4
+
+for i in 9 6; do
+    x=$(environ mc$i $(pwd))
+    mkdir -p $x/dt/{folder1,folder2,folder3}
+    echo $x/dt/{folder1,folder2,folder3}/{file1,file2}.dat | xargs -n 1 touch
+    echo 1111111111 > $x/dt/folder1/file1.dat
+    eval mc$i=$x
+done
+
+for i in 1 2 3 4; do
+    x=$(environ ap$i)
+    mkdir -p $x/dt/{folder1,folder2,folder3}
+    echo $x/dt/{folder1,folder2,folder3}/{file1,file2}.dat | xargs -n 1 touch
+    echo 1111111111 > $x/dt/folder1/file1.dat
+    eval ap$i=$x
+    $x/start
+done
+
+hq_address=$($mc9/print_address)
+na_address=$($mc6/print_address)
+na_interface=127.0.0.2
+
+# deploy db
+$mc9/gen_env MIRRORCACHE_HASHES_COLLECT=1 MIRRORCACHE_HASHES_PIECES_MIN_SIZE=5 "MIRRORCACHE_TOP_FOLDERS='folder1 folder2 folder3'"
+$mc9/backstage/shoot
+
+$mc9/sql "insert into subsidiary(hostname,region) select '$na_address','na'"
+$mc9/start
+$mc9/sql "insert into server(hostname,urldir,enabled,country,region) select '$($ap1/print_address)','','t','jp','as'"
+$mc9/sql "insert into server(hostname,urldir,enabled,country,region) select '$($ap2/print_address)','','t','jp','as'"
+
+$mc6/gen_env MIRRORCACHE_REGION=na MIRRORCACHE_HEADQUARTER=$hq_address "MIRRORCACHE_TOP_FOLDERS='folder1 folder2 folder3'"
+$mc6/start
+$mc6/sql "insert into server(hostname,urldir,enabled,country,region) select '$($ap3/print_address)','','t','us','na'"
+$mc6/sql "insert into server(hostname,urldir,enabled,country,region) select '$($ap4/print_address)','','t','ca','na'"
+
+for i in 9 6; do
+    mc$i/backstage/job -e folder_sync -a '["/folder1"]'
+    [[ $i == 6 ]] && mc$i/backstage/job -e folder_hashes_import -a '["/folder1"]' || :
+    mc$i/backstage/shoot
+    mc$i/backstage/shoot -q hashes
+done
+
+curl -s "http://$hq_address/folder1/?hashes" | grep file1.dat
+curl -s "http://$na_address/folder1/?hashes&since=2021-01-01" | grep file1.dat
+
+for i in 9 6; do
+    test b2c5860a03d2c4f1f049a3b2409b39a8 == $(mc$i/db/sql 'select md5 from hash where file_id=1')
+    test 5179db3d4263c9cb4ecf0edbc653ca460e3678b7 == $(mc$i/db/sql 'select sha1 from hash where file_id=1')
+    test 63d19a99ef7db94ddbb1e4a5083062226551cd8197312e3aa0aa7c369ac3e458 == $(mc$i/db/sql 'select sha256 from hash where file_id=1')
+    test 5179db3d4263c9cb4ecf0edbc653ca460e3678b7 == $(mc$i/db/sql 'select pieces from hash where file_id=1')
+done


### PR DESCRIPTION
To be implement in another PR:

- [ ] Schedule the new task. Maybe `FolderHashesImportScheduleFromStat` which goes through the last entries in the `stat` table (like MirrorCheckFromStat does) and if file doesn't have metadata in db, schedule the new task `FolderHashesImport`.
