### PR TITLE
Fix stat reporting as miss when ROOT_COUNTRY is set

### DIFF
--- a/lib/MirrorCache/WebAPI/Plugin/RenderFileFromMirror.pm
+++ b/lib/MirrorCache/WebAPI/Plugin/RenderFileFromMirror.pm
@@ -116,7 +116,7 @@ sub register {
                 $c->stat->redirect_to_mirror($mirror->{mirror_id}, $dm);
                 $c->emit_event('mc_mirror_country_miss', {path => $dirname, country => $country}) if $country && $country ne $mirror->{country};
             } else {
-                $c->stat->redirect_to_root($dm, 0);
+                $c->stat->redirect_to_root($dm);
             }
         }
 

--- a/lib/MirrorCache/WebAPI/Plugin/Stat.pm
+++ b/lib/MirrorCache/WebAPI/Plugin/Stat.pm
@@ -43,7 +43,7 @@ sub register($self, $app, $args) {
     1;
 }
 
-sub redirect_to_root($self, $dm, $not_miss) {
+sub redirect_to_root($self, $dm, $not_miss = undef) {
     $not_miss = $dm->root_is_hit unless defined $not_miss;
     return $self->redirect_to_mirror(0, $dm) if ($not_miss);
     return $self->redirect_to_mirror(-1, $dm);


### PR DESCRIPTION
And no mirror other mirror found, but root_is_hit() returns 1
(Only metalink and mirrorlist specific)