### PR TITLE
Add support for requests over vpn

### DIFF
--- a/lib/MirrorCache/Datamodule.pm
+++ b/lib/MirrorCache/Datamodule.pm
@@ -25,7 +25,7 @@ has c => undef, weak => 1;
 has [ '_route', '_route_len' ]; # this is '/download'
 has [ 'route', 'route_len' ]; # this may be '/download' or empty if one of TOP_FOLDERS present
 has [ 'metalink', 'metalink_accept' ];
-has [ '_ip', '_country', '_region', '_lat', '_lng' ];
+has [ '_ip', '_country', '_region', '_lat', '_lng', '_vpn' ];
 has [ '_avoid_countries' ];
 has [ '_pedantic' ];
 has [ '_scheme', '_path', '_trailing_slash' ];
@@ -66,9 +66,20 @@ sub ip_sha1($self) {
 
 sub ip($self) {
     unless (defined $self->_ip) {
-       $self->_ip($self->c->mmdb->client_ip);
+        $self->_ip($self->c->mmdb->client_ip);
     }
     return $self->_ip;
+}
+
+sub vpn($self) {
+    unless (defined $self->_vpn) {
+        if (rindex($self->ip, "10.", 0) == 0) {
+            $self->_vpn(1);
+        } else {
+            $self->_vpn(0);
+        }
+    }
+    return $self->_vpn;
 }
 
 sub region($self) {

--- a/lib/MirrorCache/WebAPI/Plugin/Dir.pm
+++ b/lib/MirrorCache/WebAPI/Plugin/Dir.pm
@@ -285,7 +285,7 @@ sub _guess_what_to_render {
         return $res;
     }
 
-    my $rootlocation = $root->location($c);
+    my $rootlocation = $root->location;
     my $url  = $rootlocation . $path;
 
     my $ua = Mojo::UserAgent->new->max_redirects(0);
@@ -327,7 +327,7 @@ sub _guess_what_to_render {
         return $root->render_file($dm, $path . $trailing_slash);
     })->catch(sub {
         my $res = $root->render_file($dm, $path . $trailing_slash);
-        my $msg = "Error while guessing how to render $path: ";
+        my $msg = "Error while guessing how to render $url: ";
         if (1 == scalar(@_)) {
             $msg = $msg . $_[0];
         } else {

--- a/lib/MirrorCache/WebAPI/Plugin/Mmdb.pm
+++ b/lib/MirrorCache/WebAPI/Plugin/Mmdb.pm
@@ -59,7 +59,7 @@ sub register {
     });
 
     if ($reader) {
-        $app->plugin('ClientIP');
+        $app->plugin('ClientIP', private => [qw(127.0.0.0/8 192.168.0.0/16)]);
         $app->helper( 'mmdb.client_ip' => sub { return shift->client_ip; } );
     } else {
         $app->helper( 'mmdb.client_ip' => sub { return shift->tx->remote_address; } );

--- a/lib/MirrorCache/resources/migrations/pg.sql
+++ b/lib/MirrorCache/resources/migrations/pg.sql
@@ -32,6 +32,7 @@ create table if not exists redirect (
 create table if not exists server (
     id serial NOT NULL PRIMARY KEY,
     hostname  varchar(128) NOT NULL UNIQUE,
+    hostname_vpn varchar(128) UNIQUE,
     urldir    varchar(128) NOT NULL,
     enabled  boolean NOT NULL,
     region  varchar(2),
@@ -205,3 +206,5 @@ create table project (
     db_sync_full_every int default 4
 );
 alter table stat add column if not exists mirrorlist boolean default 'f';
+-- 9 up
+alter table server add column if not exists hostname_vpn varchar(128) UNIQUE;

--- a/t/environ/04-rsync.sh
+++ b/t/environ/04-rsync.sh
@@ -9,6 +9,7 @@ $rs/configure_dir dt $rs/dt
 $mc/gen_env MIRRORCACHE_PEDANTIC=1 \
     MIRRORCACHE_ROOT=rsync://$USER:$USER@$($rs/print_address)/dt \
     MIRRORCACHE_REDIRECT=some.address.fake.com \
+    MIRRORCACHE_REDIRECT_VPN=some.address.fake.vpn.us \
     MIRRORCACHE_COUNTRY_RESCAN_TIMEOUT=0
 
 ap8=$(environ ap8)
@@ -35,6 +36,7 @@ rm $ap8/dt/folder1/file2.1.dat
 
 # first request redirected to MIRRORCACHE_REDIRECT, eventhough files are not there
 $mc/curl -I /download/folder1/file2.1.dat | grep fake.com
+$mc/curl -H 'X-Forwarded-For: 10.0.1.1' -I /download/folder1/file2.1.dat | grep fake.vpn.us
 
 $mc/backstage/job folder_sync_schedule_from_misses
 $mc/backstage/job folder_sync_schedule


### PR DESCRIPTION
MIRRORCACHE_REDIRECT_VPN will be used instead of MIRRORCACHE_REDIRECT if request comes from 10.*
Server gets new column hostname_vpn, which is used when requests comes from 10.*
This way MirrorCache can serve servers which have different hostnames inside vpn.