### PR TITLE
Add parameter MIRRORCACHE_VPN_PREFIX

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -14,6 +14,7 @@ MirrorCache can be configured with following environment variables:
   * MIRRORCACHE_METALINK_PUBLISHER may be set to customize publisher in metalink generation.
   * MIRRORCACHE_METALINK_PUBLISHER_URL may be set to customize url of publisher in metalink generation.
   * MIRRORCACHE_BRANDING loads files from [templates/branding](/templates/branding). Use the `default` folder as a base for your own branding and set this environment variable to the name of the newly created folder.
+  * MIRRORCACHE_VPN_PREFIX - MirrorCache can can use column server.hostname_vpn for redirecting if client IP has prefix as defined by MIRRORCACHE_VPN_PREFIX.
 
 Without any database configuration MirrorCache will attempt to connect to database 'mirrorcache' on default PostgreSQL port 5432.
 Following variables can be used to configure database access:

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -14,7 +14,7 @@ MirrorCache can be configured with following environment variables:
   * MIRRORCACHE_METALINK_PUBLISHER may be set to customize publisher in metalink generation.
   * MIRRORCACHE_METALINK_PUBLISHER_URL may be set to customize url of publisher in metalink generation.
   * MIRRORCACHE_BRANDING loads files from [templates/branding](/templates/branding). Use the `default` folder as a base for your own branding and set this environment variable to the name of the newly created folder.
-  * MIRRORCACHE_VPN_PREFIX - MirrorCache can can use column server.hostname_vpn for redirecting if client IP has prefix as defined by MIRRORCACHE_VPN_PREFIX.
+  * MIRRORCACHE_VPN_PREFIX - MirrorCache will use column server.hostname_vpn for redirecting if client IP has prefix as defined by MIRRORCACHE_VPN_PREFIX.
 
 Without any database configuration MirrorCache will attempt to connect to database 'mirrorcache' on default PostgreSQL port 5432.
 Following variables can be used to configure database access:

--- a/lib/MirrorCache/Datamodule.pm
+++ b/lib/MirrorCache/Datamodule.pm
@@ -42,6 +42,8 @@ has root_country => ($ENV{MIRRORCACHE_ROOT_COUNTRY} ? lc($ENV{MIRRORCACHE_ROOT_C
 has '_root_region';
 has '_root_longitude' => ($ENV{MIRRORCACHE_ROOT_LONGITUDE} ? int($ENV{MIRRORCACHE_ROOT_LONGITUDE}) : 11);
 
+has vpn_prefix => ($ENV{MIRRORCACHE_VPN_PREFIX} ? lc($ENV{MIRRORCACHE_VPN_PREFIX}) : "10.");
+
 sub app($self, $app) {
     $self->_route($app->mc->route);
     $self->_route_len(length($self->_route));
@@ -73,7 +75,7 @@ sub ip($self) {
 
 sub vpn($self) {
     unless (defined $self->_vpn) {
-        if (rindex($self->ip, "10.", 0) == 0) {
+        if ($self->vpn_prefix && (rindex($self->ip, $self->vpn_prefix, 0) == 0)) {
             $self->_vpn(1);
         } else {
             $self->_vpn(0);
@@ -269,9 +271,10 @@ sub _init_path($self) {
     my $url = $self->c->req->url->to_abs;
     $self->_scheme($url->scheme);
     my $pedantic;
-    if (my $query = $url->query) {
+    my $query = $url->query;
+    if (my $query_string = $url->query->to_string) {
         $self->_query($query);
-        $self->_query1('?' . $query);
+        $self->_query1('?' . $query_string);
         $self->mirrorlist(1) if defined $query->param('mirrorlist');
         $self->json(1)       if defined $query->param('json');
         $pedantic = $query->param('PEDANTIC');


### PR DESCRIPTION
MirrorCache can can use column server.hostname_vpn for redirecting
if client IP has prefix as defined by MIRRORCACHE_VPN_PREFIX.