### PR TITLE
Add support for IP2Location database

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -27,11 +27,15 @@ If neither TEST_PG nor MIRRORCACHE_DSN is defined, following variables are used:
   * MIRRORCACHE_DBPORT (default empty)
 
 ### GeoIP location
-  * If environment variable MIRRORCACHE_CITY_MMDB is defined, the app will attempt to detect country of the request and find a mirror in the same country, e.g. `MIRRORCACHE_CITY_MMDB=/var/lib/GeoIP/GeoLite2-City.mmdb`.
-  * Refer Maxmind geoip2 on how to obtain such file.
+  * If environment variable MIRRORCACHE_CITY_MMDB or MIRRORCACHE_IP2LOCATION is defined, the app will attempt to detect country of the request and find a mirror in the same country, e.g. `MIRRORCACHE_CITY_MMDB=/var/lib/GeoIP/GeoLite2-City.mmdb` or `MIRRORCACHE_IP2LOCATION=/var/lib/GeoIP/IP2LOCATION-LITE-DB5.IPV6.BIN`.
+  * See Maxmind or IP2Location website to obtain such file.
   * Additional dependencies must be installed as well for GeoIP location to work: perl modules Mojolicious::Plugin::ClientIP and MaxMind::DB::Reader :
 ```
+# for Maxmind
 zypper in perl-Mojolicious-Plugin-ClientIP perl-MaxMind-DB-Reader
+
+# for IP2Location
+zypper in perl-Geo-IP2Location
 ```
 
 ## Types of install
@@ -70,10 +74,13 @@ The best way to install them is to reuse zypper and cpanm commands from CI envir
 You may skip installing MaxMind::DB::Reader and Mojolicious::Plugin::ClientIP if you don't need Geolocation detection, if you don't need MirrorCache to find a mirror in client's country. From now on it will be referenced as 'Geolocation feature'.
 
 2. You may need GeoIP database (optional, if 'Geolocation feature' is needed).
-`/var/lib/GeoIP/GeoLite2-City.mmdb`
+`/var/lib/GeoIP/GeoLite2-City.mmdb` or `/var/lib/GeoIP/IP2LOCATION-LITE-DB5.IPV6.BIN`
 In such case you will also need following command in next step:
 ```bash
+# for MaxMind database
 echo MIRRORCACHE_CITY_MMDB=/var/lib/GeoIP/GeoLite2-City.mmdb >> /etc/mirrorcache/conf.env
+# or for IP2Location database
+echo MIRRORCACHE_IP2LOCATION=/var/lib/GeoIP/IP2LOCATION-LITE-DB5.IPV6.BIN >> /usr/share/mirrorcache/conf.env
 ```
 
 3. Setup
@@ -109,7 +116,7 @@ The best way to install them is to reuse zypper and cpanm commands from CI envir
 You may skip installing MaxMind::DB::Reader and Mojolicious::Plugin::ClientIP if you don't need Geolocation detection, if you don't need MirrorCache to find a mirror in client's country. From now on it will be referenced as 'Geolocation feature'.
 
 2. You may need GeoIP database (optional, if 'Geolocation feature' is needed).
-`/var/lib/GeoIP/GeoLite2-City.mmdb`
+`/var/lib/GeoIP/GeoLite2-City.mmdb` or `/var/lib/GeoIP/IP2LOCATION-LITE-DB5.IPV6.BIN`
 
 3. You will need PostgreSQL server running, create database for mirrorcache and create tables:
 ```
@@ -124,7 +131,7 @@ It is possible to run PostgreSQL on dedicated server as well.
 TEST_PG='DBI:Pg:dbname=mc_dev;host=/path/to/pg' \
 MIRRORCACHE_ROOT=http://download.opensuse.org \
 MIRRORCACHE_TOP_FOLDERS='debug distribution factory history ports repositories source tumbleweed update' \
-MIRRORCACHE_CITY_MMDB=/var/lib/GeoIP/GeoLite2-City.mmdb \
+MIRRORCACHE_CITY_MMDB=/var/lib/GeoIP/GeoLite2-City.mmdb \ # MIRRORCACHE_IP2LOCATION=/var/lib/GeoIP/IP2LOCATION-LITE-DB5.IPV6.BIN \
 MOJO_REVERSE_PROXY=1 \
 MOJO_LISTEN=http://*:8000 \
 script/mirrorcache daemon
@@ -169,7 +176,7 @@ mc=$(environ mc ~/github/MirrorCache)
 # pg1-system2 will setup local instance of Postgres server with data directory in pg1-system2/dt/
 $mc/gen_config MIRRORCACHE_ROOT=http://download.opensuse.org \
      MIRRORCACHE_TOP_FOLDERS="'debug distribution factory history ports repositories source tumbleweed update'" \
-    MIRRORCACHE_CITY_MMDB=/var/lib/GeoIP/GeoLite2-City.mmdb \
+    MIRRORCACHE_CITY_MMDB=/var/lib/GeoIP/GeoLite2-City.mmdb \ # MIRRORCACHE_IP2LOCATION=/var/lib/GeoIP/IP2LOCATION-LITE-DB5.IPV6.BIN \
     MOJO_REVERSE_PROXY=1
 
 $mc/start

--- a/lib/MirrorCache/Datamodule.pm
+++ b/lib/MirrorCache/Datamodule.pm
@@ -68,7 +68,7 @@ sub ip_sha1($self) {
 
 sub ip($self) {
     unless (defined $self->_ip) {
-        $self->_ip($self->c->mmdb->client_ip);
+        $self->_ip($self->c->geodb->client_ip);
     }
     return $self->_ip;
 }
@@ -237,7 +237,7 @@ sub _init_req($self) {
 }
 
 sub _init_location($self) {
-    my ($lat, $lng, $country, $region) = $self->c->mmdb->location($self->ip);
+    my ($lat, $lng, $country, $region) = $self->c->geodb->location($self->ip);
     $self->_lat($lat);
     $self->_lng($lng);
     my $query = $self->c->req->url->query;

--- a/lib/MirrorCache/Task/MirrorLocation.pm
+++ b/lib/MirrorCache/Task/MirrorLocation.pm
@@ -43,7 +43,7 @@ sub _location {
     my $uri = URI->new($hostname)->canonical;
     my $ip = $uri->host;
     $ip = nslookup($ip) unless _isValidIP($ip);
-    my ($lat, $lng, $country, $continent) = $app->mmdb->location($ip);
+    my ($lat, $lng, $country, $continent) = $app->geodb->location($ip);
     $lat = sprintf("%.3f", $lat) if $lat;
     $lng = sprintf("%.3f", $lng) if $lng;
     return $job->fail("Couldn't identify location") unless ($lat || $lng) && $country && $continent;

--- a/lib/MirrorCache/WebAPI/Controller/Rest/MyIp.pm
+++ b/lib/MirrorCache/WebAPI/Controller/Rest/MyIp.pm
@@ -19,14 +19,14 @@ use Mojo::Base 'Mojolicious::Controller';
 sub show {
     my ($c) = @_;
 
-    my $ip      = $c->mmdb->client_ip;
-    my ($region, $country) = $c->mmdb->region($ip);
+    my $ip      = $c->geodb->client_ip;
+    my ($country, $region) = $c->geodb->country_and_region($ip);
 
     $c->render(
         json => {
             ip      => $ip,
-            country => $country // 'Unknown',
-            region  => $region  // 'Unknown',
+            country => $country ? $country : 'Unknown',
+            region  => $region ? $region : 'Unknown',
         }
     );
 }

--- a/t/lib/Dockerfile.environ
+++ b/t/lib/Dockerfile.environ
@@ -13,7 +13,7 @@ RUN zypper -vvv -n install MirrorCache perl-MaxMind-DB-Reader perl-Mojolicious-P
     apache2 perl-Digest-MD4 tidy nginx bbe
 
 # dependencies to be deleted after they are merged and installed with the rpm package
-RUN zypper -vvv -n install perl-Sort-Versions
+RUN zypper -vvv -n install perl-Sort-Versions perl-Geo-IP2Location
 
 RUN zypper -vvv -n install make rsync
 


### PR DESCRIPTION
New Geolocation module using Geo::IP2Location.
New env var MIRRORCACHE_IP2LOCATION, but the file extension is checked
anyway: both .mmdb and .BIN are accepted.