### PR TITLE
Add parameter METALINK_GREEDY

### DIFF
--- a/lib/MirrorCache/Datamodule.pm
+++ b/lib/MirrorCache/Datamodule.pm
@@ -268,6 +268,7 @@ sub redirect($self, $url) {
 }
 
 sub _init_headers($self) {
+    $self->_agent('');
     my $headers = $self->c->req->headers;
     return unless $headers;
     $self->_agent($headers->user_agent ? $headers->user_agent : '');


### PR DESCRIPTION
To avoid load on main server, metalink will not contain the main server in url list anymore when mirror count exceeds value of METALINK_GREEDY