### PR TITLE
Retry hashes import if a new file hasnt got any

### DIFF
--- a/lib/MirrorCache/Task/FolderSync.pm
+++ b/lib/MirrorCache/Task/FolderSync.pm
@@ -181,9 +181,9 @@ sub _sync {
 
     $job->note(updated => $realpath, count => $cnt, deleted => $deleted, updated => $updated);
     if ($cnt || $updated) {
-        $folder->update(     {sync_last => \"CURRENT_TIMESTAMP(3)", scan_requested => \"CURRENT_TIMESTAMP(3)", sync_scheduled => \'coalesce(sync_scheduled, CURRENT_TIMESTAMP(3))'});
+        $folder->update( {sync_last => \"CURRENT_TIMESTAMP(3)", scan_requested => \"CURRENT_TIMESTAMP(3)", sync_scheduled => \'coalesce(sync_scheduled, CURRENT_TIMESTAMP(3))'});
     } else {
-        $folder->update(     {sync_last => \"CURRENT_TIMESTAMP(3)", sync_scheduled => \'coalesce(sync_scheduled, CURRENT_TIMESTAMP(3))'});
+        $folder->update( {sync_last => \"CURRENT_TIMESTAMP(3)", sync_scheduled => \'coalesce(sync_scheduled, CURRENT_TIMESTAMP(3))'});
     }
     my $need_hashes = $cnt || $updated ? 1 : 0;
     my $max_dt;


### PR DESCRIPTION
Previously hashes were missing after import in these conditions:
- the headquarter didn't have them yet;
- the calculation on headquarter hasnt finished yet. 
Now the retry will happen if some of new files are still missing hashes.