### PR TITLE
Implement realpath for remote root with nfs

### DIFF
--- a/lib/MirrorCache/WebAPI/Plugin/Dir.pm
+++ b/lib/MirrorCache/WebAPI/Plugin/Dir.pm
@@ -295,7 +295,8 @@ sub _render_from_db {
         $dirname = $dm->root_subtree . $f->dirname unless $dirname;
         $c->log->error($c->dumper('dirname:', $dirname)) if $MCDEBUG;
         if (my $parent_folder = $rsFolder->find({path => $dirname})) {
-            if ($dirname eq $root->realpath($dm->root_subtree . $f->dirname)) {
+            my $realpath_subtree = $root->realpath($dm->root_subtree . $f->dirname) // '';
+            if ($dirname eq $realpath_subtree) {
                 $dm->folder_id($parent_folder->id) if $dirname eq $f->dirname;
             } else {
                 my $another_folder = $rsFolder->find({path => $dm->root_subtree . $f->dirname});

--- a/lib/MirrorCache/WebAPI/Plugin/RenderFileFromMirror.pm
+++ b/lib/MirrorCache/WebAPI/Plugin/RenderFileFromMirror.pm
@@ -28,7 +28,7 @@ use Mojo::Date;
 use Mojo::Util;
 use Mojo::IOLoop::Subprocess;
 
-my $MCDEBUG = $ENV{MCDEBUG_RENDER_FILE_FROM_MIRROR} // $ENV{MC_DEBUG_ALL} // 0;
+my $MCDEBUG = $ENV{MCDEBUG_RENDER_FILE_FROM_MIRROR} // $ENV{MCDEBUG_ALL} // 0;
 
 sub register {
     my ($self, $app) = @_;

--- a/lib/MirrorCache/WebAPI/Plugin/RootRemote.pm
+++ b/lib/MirrorCache/WebAPI/Plugin/RootRemote.pm
@@ -60,6 +60,18 @@ sub is_remote {
 }
 
 sub realpath {
+    return undef unless $nfs;
+
+    my ($self, $path) = @_;
+    return undef unless $path;
+
+    my $localpath = $nfs . $path;
+    my $realpathlocal = Cwd::realpath($localpath);
+
+    if ($realpathlocal && (0 == rindex($realpathlocal, $nfs, 0))) {
+        my $realpath = substr($realpathlocal, length($nfs));
+        return $realpath if $realpath ne $path;
+    }
     return undef;
 }
 

--- a/t/environ/04-remote-nfs.sh
+++ b/t/environ/04-remote-nfs.sh
@@ -1,6 +1,7 @@
 #!lib/test-in-container-environ.sh
 set -ex
 
+# we need mc1 to emulate problem with nfs mount, so content of nfs is different from content of ROOT in mc2
 mc1=$(environ mc1 $(pwd))
 mc2=$(environ mc2 $(pwd))
 
@@ -10,14 +11,11 @@ FAKEURL="notexists${RANDOM}.com"
 
 MIRRORCACHE_SCHEDULE_RETRY_INTERVAL=3
 
-$mc1/gen_env \
-    MIRRORCACHE_SCHEDULE_RETRY_INTERVAL=$MIRRORCACHE_SCHEDULE_RETRY_INTERVAL \
-    MIRRORCACHE_REDIRECT=$FAKEURL
-
 $mc2/gen_env \
     MIRRORCACHE_ROOT=http://$($ap9/print_address) \
     MIRRORCACHE_SCHEDULE_RETRY_INTERVAL=$MIRRORCACHE_SCHEDULE_RETRY_INTERVAL \
-    MIRRORCACHE_ROOT_NFS=$mc2/dt
+    MIRRORCACHE_REDIRECT=$FAKEURL \
+    MIRRORCACHE_ROOT_NFS=$mc1/dt
 
 rm -r $mc2/db
 ln -s $mc1/db $mc2/
@@ -46,40 +44,37 @@ $mc1/status
 $mc2/start
 $mc2/status
 
-$mc1/sql "insert into server(hostname,urldir,enabled,country,region) select '$($ap7/print_address)','','t','us','na'"
+$mc2/sql "insert into server(hostname,urldir,enabled,country,region) select '$($ap7/print_address)','','t','us','na'"
 
 # remove one of folders from NFS, imitating mount issue
-rm -r $mc2/dt/folder2
+rm -r $mc1/dt/folder2
 
 echo first time REDIRECT is used
-$mc1/curl -I /download/folder1/file1.1.dat | grep -C30 '302 Found' | grep $FAKEURL
+$mc2/curl -I /download/folder1/file1.1.dat | grep -C30 '302 Found' | grep $FAKEURL
 
 echo first time REDIRECT is used even if folder is missing from NFS
-$mc1/curl -I /download/folder2/file1.1.dat | grep -C30 '302 Found' | grep $FAKEURL
+$mc2/curl -I /download/folder2/file1.1.dat | grep -C30 '302 Found' | grep $FAKEURL
 
 $mc2/backstage/job -e folder_sync_schedule_from_misses
-# $mc/backstage/shoot
 $mc2/backstage/job -e folder_sync_schedule
-# $mc/backstage/shoot
 $mc2/backstage/job -e mirror_scan_schedule
 $mc2/backstage/shoot
 
-$mc1/sql_test 2 == "select count(*) from minion_jobs where task = 'folder_sync'"
-$mc1/sql_test 2 == "select count(*) from folder"
+$mc2/sql_test 2 == "select count(*) from minion_jobs where task = 'folder_sync'"
+$mc2/sql_test 2 == "select count(*) from folder"
 
-$mc1/curl -I /download/folder1/file1.1.dat | grep -C30 '302 Found' | grep $($ap7/print_address)
+$mc2/curl -I /download/folder1/file1.1.dat | grep -C30 '302 Found' | grep $($ap7/print_address)
 
 echo Now the scan happened despite the folder is missing in ROOT_NFS
-$mc1/curl -I /download/folder2/file1.1.dat | grep -C30 '302 Found' | grep $($ap7/print_address)
+$mc2/curl -I /download/folder2/file1.1.dat | grep -C30 '302 Found' | grep $($ap7/print_address)
 
-$mc1/curl /download/updates/tool/latest/file1.1.dat.meta4 | grep $($ap7/print_address)/folder1/file1.1.dat
+$mc2/curl /download/updates/tool/latest/file1.1.dat.meta4 | grep $($ap7/print_address)/folder1/file1.1.dat
 
 sleep $MIRRORCACHE_SCHEDULE_RETRY_INTERVAL
 
 $mc2/backstage/shoot
 
 echo now we learned about all 3 folders
-mc1/sql_test 3 == 'select count(*) from folder'
-
+$mc2/sql_test 3 == 'select count(*) from folder'
 
 echo success

--- a/templates/branding/openSUSE/footer.html.ep
+++ b/templates/branding/openSUSE/footer.html.ep
@@ -9,7 +9,7 @@
         <a class="list-inline-item" href="https://github.com/openSUSE/MirrorCache">Source code</a>
         <a class="list-inline-item" href="https://bugzilla.opensuse.org/">Report issue</a>
         % if (my $ver = eval '$current_version') {
-        <a>Version <%= $ver %></a>
+        <a>MirrorCache <%= $ver %></a>
         % }
       </div>
       % if (my $msg = eval '$custom_footer_message') {


### PR DESCRIPTION
The test 04-remote-nfs was incorrect and didn't test realpath for RootRemote (it was working with mc1 instead of mc2).
This fixes the test and adds missing functionality.