### PR TITLE
Redirect Current.iso when no nfs mount

### DIFF
--- a/lib/MirrorCache/WebAPI/Plugin/RootLocal.pm
+++ b/lib/MirrorCache/WebAPI/Plugin/RootLocal.pm
@@ -149,7 +149,7 @@ if ($TOP_FOLDERS) {
     }
 }
 
-sub _detect_ln {
+sub _detect_ln_in_the_same_folder {
     my ($dir, $file) = @_;
     return undef unless $file && $file =~ m/.*(Media|Current)\.iso(\.sha256)?/;
 
@@ -167,10 +167,10 @@ sub _detect_ln {
     return undef;
 }
 
-sub detect_ln {
+sub detect_ln_in_the_same_folder {
     my ($self, $path) = @_;
     my $f = Mojo::File->new($path);
-    my $res = _detect_ln($f->dirname, $f->basename);
+    my $res = _detect_ln_in_the_same_folder($f->dirname, $f->basename);
     return undef unless $res;
     return $f->dirname . '/' . $res;
 }

--- a/t/environ/04-remote-current-no-nfs.sh
+++ b/t/environ/04-remote-current-no-nfs.sh
@@ -1,0 +1,69 @@
+#!lib/test-in-container-environ.sh
+set -ex
+
+mc=$(environ mc $(pwd))
+
+ap9=$(environ ap9)
+
+$mc/gen_env \
+    MIRRORCACHE_SCHEDULE_RETRY_INTERVAL=0 \
+    MIRRORCACHE_ROOT=http://$($ap9/print_address) \
+
+ap8=$(environ ap8)
+ap7=$(environ ap7)
+
+for x in $ap7 $ap8 $ap9; do
+    mkdir -p $x/dt/{folder1,folder2,folder3}
+    echo $x/dt/{folder1,folder2,folder3}/{file1.1,file2.1}-Media.iso | xargs -n 1 touch
+    sha256sum $x/dt/folder1/file1.1-Media.iso > $x/dt/folder1/file1.1-Media.iso.sha256
+    echo 111112 > $x/dt/folder1/file2.1-Media.iso
+    sha256sum $x/dt/folder1/file2.1-Media.iso > $x/dt/folder1/file2.1-Media.iso.sha256
+    ( cd $x/dt/folder1 && ln -s file1.1-Media.iso file-Media.iso && ln -s file1.1-Media.iso.sha256 file-Media.iso.sha256 )
+done
+
+echo '    RewriteEngine On
+    RewriteBase "/"
+    RewriteRule ^folder1/file-Media.iso(.*)?$ folder1/file1.1-Media.iso$1 [R]
+' > $ap9/directory-rewrite.conf
+
+echo 'LoadModule rewrite_module    /usr/lib64/apache2-prefork/mod_rewrite.so' > $ap9/extra-rewrite.conf
+
+for x in $ap7 $ap8 $ap9; do
+    $x/start
+done
+
+$mc/start
+$mc/status
+
+$mc/sql "insert into server(hostname,urldir,enabled,country,region) select '$($ap7/print_address)','','t','us','na'"
+$mc/sql "insert into server(hostname,urldir,enabled,country,region) select '$($ap8/print_address)','','t','us','na'"
+
+$mc/backstage/job -e folder_sync -a '["/folder1"]'
+$mc/backstage/shoot
+
+
+$mc/sql "select * from file"
+
+################################################
+# Test unversioned Media.iso is redirected to file which is metioned inside corresponding Media.iso.sha256
+$mc/curl -I /download/folder1/file-Media.iso        | grep -C 10 302 | grep /download/folder1/file1.1-Media.iso
+$mc/curl -I /download/folder1/file-Media.iso.sha256 | grep -C 10 302 | grep /download/folder1/file1.1-Media.iso.sha256
+$mc/curl -L /download/folder1/file-Media.iso.sha256 | grep -q "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  "
+
+echo now change the symlink and make sure redirect changes
+echo '    RewriteEngine On
+    RewriteBase "/"
+    RewriteRule ^folder1/file-Media.iso(.*)?$ folder1/file2.1-Media.iso$1 [R]
+' > $ap9/directory-rewrite.conf
+
+$ap9/stop
+$ap9/start
+
+$mc/backstage/job -e folder_sync -a '["/folder1"]'
+$mc/backstage/shoot
+$mc/curl -I /download/folder1/file-Media.iso        | grep -C 10 302 | grep /download/folder1/file2.1-Media.iso
+$mc/curl -I /download/folder1/file-Media.iso.sha256 | grep -C 10 302 | grep /download/folder1/file2.1-Media.iso.sha256
+$mc/curl -L /download/folder1/file-Media.iso.sha256 | grep -q "2019dd7afaf5759c68cec4d0e7553227657f01c69da168489116a1c48e40270e  "
+
+echo success
+

--- a/templates/dir.html.ep
+++ b/templates/dir.html.ep
@@ -5,7 +5,7 @@
 % my $full_path = $cur_path;
 % $full_path = $route . $cur_path unless $route eq '/';
 % my @breadcrumbs = split '/', $full_path;
-% my $bc_last = pop @breadcrumbs;
+% my $bc_last = pop @breadcrumbs // '';
 %= include 'layouts/info'
 
 % my $mc_branding = eval '$branding' // '';
@@ -21,11 +21,11 @@
 
 <style type='text/css'>
 
-a {
+tr.td.a {
   display: flex;
 }
 
-a::after{
+tr.td.a::after{
   content: var(--desc);
   color: grey;
   margin-left: auto;


### PR DESCRIPTION
Previosly MirrorCache could properly detect correct redirect for Current.iso files only when files were available on disk.