### PR TITLE
Secure last_id for jobs monitoring stat

### DIFF
--- a/lib/MirrorCache/Schema/ResultSet/Stat.pm
+++ b/lib/MirrorCache/Schema/ResultSet/Stat.pm
@@ -254,4 +254,13 @@ END_SQL
     return ($id, \@folder_ids, \@country_list);
 }
 
+sub secure_max_id {
+    my ($self, $prev_stat_id) = @_;
+    my $max_id = $self->get_column("id")->max;
+
+    $prev_stat_id = $max_id - 100000 if !$prev_stat_id || $max_id - $prev_stat_id > 10000 || $prev_stat_id > $max_id;
+    $prev_stat_id = 0 if $prev_stat_id < 0;
+    return $prev_stat_id;
+}
+
 1;

--- a/lib/MirrorCache/Task/FolderSyncScheduleFromMisses.pm
+++ b/lib/MirrorCache/Task/FolderSyncScheduleFromMisses.pm
@@ -46,6 +46,9 @@ sub _run {
     my $schema = $app->schema;
     my $limit = 10000;
 
+    $prev_stat_id = $schema->resultset('Stat')->secure_max_id($prev_stat_id);
+    print(STDERR "$pref id after adjust: $prev_stat_id\n") if $MCDEBUG;
+
     my ($stat_id, $folders, $country_list) = $schema->resultset('Stat')->path_misses($prev_stat_id, $limit);
     $common_guard = undef;
     my $rs = $schema->resultset('Folder');

--- a/lib/MirrorCache/Task/MirrorCheckFromStat.pm
+++ b/lib/MirrorCache/Task/MirrorCheckFromStat.pm
@@ -45,6 +45,8 @@ sub _run {
 
     my $schema = $app->schema;
 
+    $prev_stat_id = $schema->resultset('Stat')->secure_max_id($prev_stat_id);
+
     my ($stat_id, $mirror_id, $country, $url, $folder, $folder_id) = $schema->resultset('Stat')->latest_hit($prev_stat_id);
     my $last_run = 0;
     while ($stat_id && $stat_id > $prev_stat_id) {

--- a/lib/MirrorCache/Task/MirrorScanScheduleFromMisses.pm
+++ b/lib/MirrorCache/Task/MirrorScanScheduleFromMisses.pm
@@ -47,6 +47,8 @@ sub _run {
     my $schema = $app->schema;
     my $limit = $prev_stat_id ? 1000 : 10;
 
+    $prev_stat_id = $schema->resultset('Stat')->secure_max_id($prev_stat_id);
+
     my ($stat_id, $folder_ids, $country_list) = $schema->resultset('Stat')->mirror_misses($prev_stat_id, $limit);
     $common_guard = undef;
     my $rs = $schema->resultset('Folder');

--- a/t/environ/02-files.sh
+++ b/t/environ/02-files.sh
@@ -93,7 +93,8 @@ done
 # first request will miss
 $mc/curl -I /download/folder1/file3.1.dat | grep 200
 
-$mc/backstage/job folder_sync_schedule_from_misses
+# pass too big value for prev_stat_id and make sure it is automatically adjusted
+$mc/backstage/job -e folder_sync_schedule_from_misses -a '["1000000"]'
 $mc/backstage/job folder_sync_schedule
 $mc/backstage/shoot
 $mc/backstage/job mirror_scan_schedule


### PR DESCRIPTION
On some conditions the jobs may receive either too big or too small parameter. This commit makes sure that value is in adequate range.