### PR TITLE
Fix huge files rendered from REDIRECT_HUGE only for metalink 

### DIFF
--- a/lib/MirrorCache/WebAPI/Plugin/Dir.pm
+++ b/lib/MirrorCache/WebAPI/Plugin/Dir.pm
@@ -333,11 +333,6 @@ sub _render_from_db {
                     $path = $path . '.zsync';
                 }
 
-                $c->log->error($c->dumper('file_size: ', $file->{size} // 'undef', 'huge_file_size: ', $mc_config->huge_file_size)) if $MCDEBUG;
-                if ($root->is_remote && !$dm->extra && $file->{size} && $mc_config->redirect_huge && $mc_config->huge_file_size <= $file->{size}) {
-                    $dm->redirect($dm->scheme . '://' . $mc_config->redirect_huge . $path);
-                    return 1;
-                }
                 if ($file->{target}) {
                     # redirect to the symlink
                     $dm->redirect($dm->route . $dirname . '/' . $file->{target});

--- a/lib/MirrorCache/WebAPI/Plugin/RenderFileFromMirror.pm
+++ b/lib/MirrorCache/WebAPI/Plugin/RenderFileFromMirror.pm
@@ -309,6 +309,11 @@ sub register {
         }
 
         unless ($mirror) {
+            if ($root->is_remote && $file->{size} && $mc_config->redirect_huge && $mc_config->huge_file_size <= $file->{size}) {
+                $dm->redirect($dm->scheme . '://' . $mc_config->redirect_huge . $filepath);
+                return 1;
+            }
+
             $root->render_file($dm, $filepath);
             return 1;
         }


### PR DESCRIPTION
when with remote root.
Basically implementation was in wrong place (too early) and the test didn't cover redirection to mirror when needed.
Metalinks worked fine though, so mostly .iso download was impacted only.