### PR TITLE
Don't send users to Bugzilla

### DIFF
--- a/templates/branding/openSUSE/footer.html.ep
+++ b/templates/branding/openSUSE/footer.html.ep
@@ -7,7 +7,7 @@
       <div class="list-inline">
         <a class="list-inline-item" href="https://en.opensuse.org/Imprint">Legal notice</a>
         <a class="list-inline-item" href="https://github.com/openSUSE/MirrorCache">Source code</a>
-        <a class="list-inline-item" href="https://bugzilla.opensuse.org/">Report issue</a>
+        <a class="list-inline-item" href="https://github.com/openSUSE/MirrorCache/issues/new">Report issue</a>
         % if (my $ver = eval '$current_version') {
         <a>MirrorCache <%= $ver %></a>
         % }


### PR DESCRIPTION
There are no categories in Bugzilla for MirrorCache which makes it confusing and frustrating.

At very least we should have a bugzilla link to creating a bug there with prefilled category and assignee. Until that time, the README in the source repo is much more helpful.
