### PR TITLE
Service subtree config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
         type: string
         default: ""
     machine:
-      image: ubuntu-2004:202008-01
+      image: ubuntu-2204:2023.04.2
     environment:
       MIRRORCACHE_DB_PROVIDER: << parameters.db >>
       T_EXPERIMENTAL: << parameters.db >>
@@ -22,17 +22,6 @@ jobs:
             echo '{ "ipv6": true,  "fixed-cidr-v6": "fd00::/80" }' | sudo tee /etc/docker/daemon.json
             sudo systemctl restart docker
       - run: make test_docker
-
-  systemd:
-    machine:
-      image: ubuntu-2004:202008-01
-    environment:
-      PRIVILEGED_TESTS: 1
-    working_directory: ~/project
-    steps:
-      - checkout:
-          path: ~/project
-      - run: make test_systemd
 
 workflows:
   version: 2.1
@@ -57,7 +46,3 @@ workflows:
           filters:
             branches:
               ignore: gh-pages
-      - systemd:
-          filters:
-              branches:
-                ignore: gh-pages

--- a/.github/workflows/t-systemd.yml
+++ b/.github/workflows/t-systemd.yml
@@ -1,0 +1,17 @@
+---
+name: CI-systemd
+
+on:
+  push:
+    branches:
+      - master
+  pull_request: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: t
+        run: |
+          make test_systemd

--- a/dist/systemd/mirrorcache-subtree.service
+++ b/dist/systemd/mirrorcache-subtree.service
@@ -1,11 +1,14 @@
 [Unit]
 Description=MirrorCache subtree webApp
+Before=apache2.service
+After=postgresql.service mariadb.service nss-lookup.target
 
 [Service]
 User=mirrorcache
 Group=mirrorcache
-ExecStart=/usr/share/mirrorcache/script/mirrorcache-daemon
+EnvironmentFile=-/etc/mirrorcache/conf.env
 EnvironmentFile=/etc/mirrorcache/conf-subtree.env
+ExecStart=/usr/share/mirrorcache/script/mirrorcache-daemon
 
 [Install]
 WantedBy=multi-user.target

--- a/t/lib/Dockerfile.systemd.mariadb
+++ b/t/lib/Dockerfile.systemd.mariadb
@@ -1,26 +1,18 @@
 FROM registry.opensuse.org/opensuse/leap:15.4
-ENV container docker
+ENV container podman
 
 ENV LANG en_US.UTF-8
 
-RUN sed -i 's,http://download.opensuse.org,https://mirrorcache.opensuse.org/download,g' /etc/zypp/repos.d/*repo
-RUN zypper ar -f https://mirrorcache.opensuse.org/repositories/openSUSE:infrastructure:MirrorCache/15.4 mc
-RUN zypper ar -f https://download.opensuse.org/repositories/devel:/languages:/perl/15.4 perl
+RUN zypper ar -f http://mirrorcache.opensuse.org/repositories/openSUSE:infrastructure:MirrorCache/15.4 mc
 RUN zypper --gpg-auto-import-keys ref
+
+RUN zypper -vvvn install systemd curl sudo iputils vi
 
 # install MirrorCache here to fetch all dependencies
 RUN zypper -vvv -n install MirrorCache perl-MaxMind-DB-Reader perl-Mojolicious-Plugin-ClientIP \
     vim mariadb mariadb-server curl sudo git-core wget tar m4 \
     apache2 perl-Digest-MD4 tidy nginx bbe perl-DBD-mysql perl-Mojo-mysql perl-Minion-Backend-mysql perl-DateTime-HiRes make \
     perl-Config-IniFiles
-
-VOLUME ["/sys/fs/cgroup"]
-VOLUME ["/run"]
-VOLUME ["/opt/project"]
-
-RUN systemctl enable dbus.service
-RUN systemctl enable mariadb
-
 
 ADD src/city.mmdb /var/lib/GeoIP/GeoLite2-City.mmdb
 

--- a/t/lib/Dockerfile.systemd.postgresql
+++ b/t/lib/Dockerfile.systemd.postgresql
@@ -1,26 +1,17 @@
 FROM registry.opensuse.org/opensuse/leap:15.4
-ENV container docker
+ENV container podman
 
 ENV LANG en_US.UTF-8
 
-RUN sed -i 's,http://download.opensuse.org,http://mirrorcache.opensuse.org/download,g' /etc/zypp/repos.d/*repo
 RUN zypper ar -f http://mirrorcache.opensuse.org/repositories/openSUSE:infrastructure:MirrorCache/15.4 mc
 RUN zypper --gpg-auto-import-keys ref
+
+RUN zypper -vvvn install systemd curl sudo iputils vi
 
 # install MirrorCache here to fetch all dependencies
 RUN zypper -vvv -n install MirrorCache perl-MaxMind-DB-Reader perl-Mojolicious-Plugin-ClientIP \
     vim postgresql postgresql-server curl sudo git-core wget tar m4 \
     apache2 perl-Digest-MD4 tidy make perl-DateTime-HiRes perl-Config-IniFiles
-
-# dependencies to be deleted after they are merged and installed with the rpm package
-RUN zypper -vvv -n install perl-Sort-Versions
-
-VOLUME ["/sys/fs/cgroup"]
-VOLUME ["/run"]
-VOLUME ["/opt/project"]
-
-RUN systemctl enable dbus.service
-RUN systemctl enable postgresql
 
 # let pg initialize data dir in cache to save some time on every run
 RUN sudo -u postgres /usr/share/postgresql/postgresql-script start && \


### PR DESCRIPTION
There is no need to repeat all parameters in conf-subtree.env, while service file can optionally include conf.env
(needed for subtree state in mirrorcache-formula)