### PR TITLE
Fix escaping in regexps

### DIFF
--- a/lib/MirrorCache/Datamodule.pm
+++ b/lib/MirrorCache/Datamodule.pm
@@ -580,7 +580,7 @@ sub _init_path($self) {
     $self->agent; # parse headers
     if (
         ( $self->accept_all || !$self->extra )
-        && $path =~ m/.*\/(repodata\/repomd.xml[^\/]*|media\.1\/(media|products)|content|.*\.sha256(\.asc)|Release(.key|.gpg)?|InRelease|Packages(.gz)?|Sources(.gz)?|.*_Arch\.(files|db|key)(\.(sig|tar\.gz(\.sig)?))?|(files|primary|other).xml.gz|[Pp]ackages(\.[A-Z][A-Z])?\.(xz|gz)|gpg-pubkey.*\.asc|CHECKSUMS(.asc)?)$/ 
+        && $path =~ m/\/(repodata\/repomd\.xml[^\/]*|media\.1\/(media|products)|content|.*\.sha256(\.asc)|Release(\.key|\.gpg)?|InRelease|Packages(\.gz)?|Sources(\.gz)?|.*_Arch\.(files|db|key)(\.(sig|tar\.gz(\.sig)?))?|(files|primary|other)\.xml\.gz|[Pp]ackages(\.[A-Z][A-Z])?\.(xz|gz)|gpg-pubkey.*\.asc|CHECKSUMS(\.asc)?)$/
     ) {
         $self->must_render_from_root(1);
         my $time = ~time() & 0xff;

--- a/lib/MirrorCache/Schema/ResultSet/Stat.pm
+++ b/lib/MirrorCache/Schema/ResultSet/Stat.pm
@@ -184,7 +184,7 @@ where
 or
 	( folder_id is null and mirror_id > -2 ) -- file may be known, but requested folder is unknown - happens when realpath shows to a different folder
 )
-and stat.path !~ '.*\/(repodata\/repomd.xml[^\/]*|media\.1\/(media|products)|content|.*\.sha256(\.asc)|Release(.key|.gpg)?|InRelease|Packages(.gz)?|Sources(.gz)?|.*_Arch\.(files|db|key)(\.(sig|tar\.gz(\.sig)?))?|(files|primary|other).xml.gz|[Pp]ackages(\.[A-Z][A-Z])?\.(xz|gz)|gpg-pubkey.*\.asc|CHECKSUMS)$'
+and stat.path !~ '\/(repodata\/repomd\.xml[^\/]*|media\.1\/(media|products)|content|.*\.sha256(\.asc)|Release(\.key|\.gpg)?|InRelease|Packages(\.gz)?|Sources(\.gz)?|.*_Arch\.(files|db|key)(\.(sig|tar\.gz(\.sig)?))?|(files|primary|other)\.xml\.gz|[Pp]ackages(\.[A-Z][A-Z])?\.(xz|gz)|gpg-pubkey.*\.asc|CHECKSUMS(\.asc)?)$'
 and lower(stat.agent) NOT LIKE '%bot%'
 and lower(stat.agent) NOT LIKE '%rclone%'
 and (


### PR DESCRIPTION
The literal dots need to be escaped. Also remove unanchored ".*" as they are very expensive to process