### PR TITLE
Allow caches to serve files while re-checking

### DIFF
--- a/lib/MirrorCache/Datamodule.pm
+++ b/lib/MirrorCache/Datamodule.pm
@@ -618,7 +618,7 @@ sub _init_path($self) {
         my $time = ~time() & 0xff;
         my $time2 = 60*60 + $time; # allow caches to serve content for 1h while they re-check
 
-        $self->c->res->headers->cache_control("public, max-age=$time stale-while-revalidate=$time2");
+        $self->c->res->headers->cache_control("public, max-age=$time stale-while-revalidate=$time2 stale-if-error=86400");
     }
 
     my ($ext) = $path =~ /([^.]+)$/;

--- a/lib/MirrorCache/Datamodule.pm
+++ b/lib/MirrorCache/Datamodule.pm
@@ -616,8 +616,9 @@ sub _init_path($self) {
     ) {
         $self->must_render_from_root(1);
         my $time = ~time() & 0xff;
+        my $time2 = 60*60 + $time; # allow caches to serve content for 1h while they re-check
 
-        $self->c->res->headers->cache_control("public, max-age=$time");
+        $self->c->res->headers->cache_control("public, max-age=$time stale-while-revalidate=$time2");
     }
 
     my ($ext) = $path =~ /([^.]+)$/;


### PR DESCRIPTION
This helps to serve content without adding latency and also avoids most trouble from stale caches
when purging is late or broken.

Also Add stale-if-error
    
so that the CDN can hide (parts of) outages of MirrorCache
