### PR TITLE
systemd: MOJO_TMPDIR=/var/lib/mirrorcache/tmp

### DIFF
--- a/dist/rpm/MirrorCache-tmpfilesd.conf
+++ b/dist/rpm/MirrorCache-tmpfilesd.conf
@@ -1,4 +1,4 @@
 # Type Path Mode UID GID Age Argument
 d /var/lib/mirrorcache 0750 mirrorcache mirrorcache - -
+d /var/lib/mirrorcache/tmp 0750 mirrorcache mirrorcache 2h
 d /run/mirrorcache 0750 mirrorcache mirrorcache - -
-d /tmp/mirrorcache - mirrorcache mirrorcache 8h

--- a/dist/systemd/mirrorcache-backstage-hashes.service
+++ b/dist/systemd/mirrorcache-backstage-hashes.service
@@ -12,7 +12,7 @@ RestartSec=10
 EnvironmentFile=/etc/mirrorcache/conf.env
 EnvironmentFile=-/etc/mirrorcache/conf-hashes.env
 WorkingDirectory=/var/lib/mirrorcache
-Environment="MOJO_TMPDIR=/tmp/mirrorcache"
+Environment="MOJO_TMPDIR=/var/lib/mirrorcache/tmp"
 
 [Install]
 WantedBy=multi-user.target

--- a/dist/systemd/mirrorcache-backstage.service
+++ b/dist/systemd/mirrorcache-backstage.service
@@ -11,7 +11,7 @@ Restart=on-failure
 RestartSec=10
 EnvironmentFile=/etc/mirrorcache/conf.env
 WorkingDirectory=/var/lib/mirrorcache
-Environment="MOJO_TMPDIR=/tmp/mirrorcache"
+Environment="MOJO_TMPDIR=/var/lib/mirrorcache/tmp"
 
 [Install]
 WantedBy=multi-user.target

--- a/dist/systemd/mirrorcache-hypnotoad.service
+++ b/dist/systemd/mirrorcache-hypnotoad.service
@@ -13,7 +13,7 @@ ExecReload=/usr/share/mirrorcache/script/mirrorcache-hypnotoad
 EnvironmentFile=/etc/mirrorcache/conf.env
 KillMode=process
 WorkingDirectory=/var/lib/mirrorcache
-Environment="MOJO_TMPDIR=/tmp/mirrorcache"
+Environment="MOJO_TMPDIR=/var/lib/mirrorcache/tmp"
 
 [Install]
 WantedBy=multi-user.target

--- a/dist/systemd/mirrorcache-subtree.service
+++ b/dist/systemd/mirrorcache-subtree.service
@@ -10,7 +10,7 @@ EnvironmentFile=-/etc/mirrorcache/conf.env
 EnvironmentFile=/etc/mirrorcache/conf-subtree.env
 ExecStart=/usr/share/mirrorcache/script/mirrorcache-daemon
 WorkingDirectory=/var/lib/mirrorcache
-Environment="MOJO_TMPDIR=/tmp/mirrorcache"
+Environment="MOJO_TMPDIR=/var/lib/mirrorcache/tmp"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
[ci skip]
Previous value /tmp/mirrorcache has security implications and was not allowed to Factory