### PR TITLE
Update copyright year range from footer (extended to 2025)

### DIFF
--- a/templates/branding/openSUSE/footer.html.ep
+++ b/templates/branding/openSUSE/footer.html.ep
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="d-flex justify-content-between">
       <div class="footer-copyright">
-        &copy; 2021-2024 SUSE LLC., openSUSE contributors
+        &copy; 2021-2025 SUSE LLC., openSUSE contributors
       </div>
       <div class="list-inline">
         <a class="list-inline-item" href="https://en.opensuse.org/Imprint">Legal notice</a>


### PR DESCRIPTION
Changed the copyright years range from `2021-2024` to `2021-2025` within the footer.