### PR TITLE
Add more exceptions to folder mirrorlist

### DIFF
--- a/lib/MirrorCache/Schema/ResultSet/Server.pm
+++ b/lib/MirrorCache/Schema/ResultSet/Server.pm
@@ -109,7 +109,7 @@ sub mirrors_query {
     my $folder_cond = "fd.folder_id in (coalesce((select id from folder where path = concat(?::text,'/repodata')),?),?) and (fdf.file_id is NULL and fl.folder_id in (coalesce((select id from folder where path = concat(?::text,'/repodata')),?),?))";
     my $where_recent = "where s.mtime > 0";
     # license.tar* and info.xml* might be kept with the same name through updates, so timestamp on them is unreliable in mirrorlist for folders
-    my $file_dt = ", max(case when fdf.file_id is null and fl.name ~ '[0-9]' and fl.name not like '%license.tar.%' and fl.name not like '%info.xml.%' and fl.name not like '%.asc' and fl.name not like '%.txt' and fl.name not like '%/' and fl.name not like 'yast2%' and fl.name not like '%.pf2' and fl.name not like '%patterns.xml.zst' then fl.mtime else null end) as mtime";
+    my $file_dt = ", max(case when fdf.file_id is null and fl.name ~ '[0-9]' and fl.name not like '%license.tar.%' and fl.name not like '%info.xml.%' and fl.name not like '%.asc' and fl.name not like '%.txt' and fl.name not like '%/' and fl.name not like 'yast2%' and fl.name not like '%.pf2' and fl.name not like '%patterns.xml.zst' and fl.name not like '%susedata%xml%' and fl.name not like '%appdata-icons%' then fl.mtime else null end) as mtime";
     my $group_by = "group by s.id, s.hostname, s.hostname_vpn, s.urldir, s.region, s.country, s.lat, s.lng, s.score, fd.folder_id";
 
     if ($file_id) {

--- a/t/lib/Dockerfile.environ.mariadb.experimental
+++ b/t/lib/Dockerfile.environ.mariadb.experimental
@@ -5,7 +5,7 @@ ENV LANG en_US.UTF-8
 
 RUN zypper -n in curl # rpm --import needs curl atm
 RUN zypper ar -f http://cdn.opensuse.org/repositories/openSUSE:infrastructure:MirrorCache/15.6 mc
-RUN zypper ar -f https://mirror.mariadb.org/yum/11.7/sles/15/x86_64 mariadb
+RUN zypper ar -f https://mirror.mariadb.org/yum/11.4/sles15-amd64 mariadb
 RUN rpm --import https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
 RUN zypper --gpg-auto-import-keys ref
 


### PR DESCRIPTION
We exclude all files that might be shipped in repodata with the same name and different mtime