### PR TITLE
fix(stats): prevent package download totals from resetting during aggregation

### DIFF
--- a/lib/MirrorCache/Task/StatAggPkg.pm
+++ b/lib/MirrorCache/Task/StatAggPkg.pm
@@ -92,14 +92,11 @@ sub _agg_total {
 
     my $dbh = $app->schema->storage->dbh;
     my $sql = "
-insert into agg_download_pkg select '$period'::stat_period_t, date_trunc('day',now()), d1.metapkg_id, d1.folder_id, d1.country, coalesce(d2.cnt, 0) + sum(d1.cnt)
-from
-agg_download_pkg d1
-left join ( select max(dt) as dt from agg_download_pkg where period = '$period'::stat_period_t ) x on 1 = 1
-left join agg_download_pkg d2 on (d2.metapkg_id, d2.folder_id, d2.country, d2.period, d2.dt) = (d1.metapkg_id, d1.folder_id, d1.country, '$period'::stat_period_t, x.dt)
-where
-d1.period = 'day'::stat_period_t and d1.dt > coalesce(x.dt, now() - interval '1 year')
-group by d1.metapkg_id, d1.folder_id, d1.country, d2.cnt
+insert into agg_download_pkg select '$period'::stat_period_t, date_trunc('day',now()), d1.metapkg_id, d1.folder_id, d1.country, coalesce((select d2.cnt from agg_download_pkg d2 where d2.period = '$period'::stat_period_t and d2.metapkg_id = d1.metapkg_id and d2.folder_id = d1.folder_id and d2.country = d1.country order by d2.dt desc limit 1), 0) + sum(d1.cnt)
+from agg_download_pkg d1
+cross join ( select coalesce(max(dt), now() - interval '1 year') as dt from agg_download_pkg where period = '$period'::stat_period_t ) gx
+where d1.period = 'day'::stat_period_t and d1.dt > gx.dt
+group by d1.metapkg_id, d1.folder_id, d1.country
 ";
 
     if ($dbh->{Driver}->{Name} ne 'Pg') {

--- a/lib/MirrorCache/WebAPI/Controller/Rest/Metapkg.pm
+++ b/lib/MirrorCache/WebAPI/Controller/Rest/Metapkg.pm
@@ -180,21 +180,21 @@ sub stat_download {
     $sql = <<'END_SQL';
 select
   extract(epoch from ( select min(dt) from agg_download_pkg where metapkg_id = ? and period = 'day' ))::int as first_seen,
-  coalesce( (select sum(cnt) as cnt from agg_download_pkg where metapkg_id = ? and period = 'total' and dt = (select max(dt) from agg_download_pkg where period = 'total')), 0 ) as cnt_total,
-  coalesce( (select sum(cnt) as cnt from agg_download_pkg where metapkg_id = ? and period = 'hour'  and dt > (select max(dt) from agg_download_pkg where period = 'total')), 0 ) as cnt_today,
+  coalesce( (select sum(cnt) as cnt from agg_download_pkg where metapkg_id = ? and period = 'total' and dt = (select max(dt) from agg_download_pkg where metapkg_id = ? and period = 'total')), 0 ) as cnt_total,
+  coalesce( (select sum(cnt) as cnt from agg_download_pkg where metapkg_id = ? and period = 'hour'  and dt > (select max(dt) from agg_download_pkg where metapkg_id = ? and period = 'total')), 0 ) as cnt_today,
   sum(cnt) as cnt_30d,
   coalesce( sum(case when dt > now() - interval '7 day' then cnt else 0 end), 0 ) as cnt_7d,
   coalesce( sum(case when dt > now() - interval '1 day' then cnt else 0 end), 0) as cnt_1d
-from agg_download_pkg
-where metapkg_id = ? and period = 'day' and dt > now() - interval '30 day'
+  from agg_download_pkg
+  where metapkg_id = ? and period = 'day' and dt > now() - interval '30 day'
 END_SQL
     unless ($self->schema->pg) {
         $sql =~ s/::int//g;
         $sql =~ s/interval '(\d+) day'/interval $1 day/g;
-        $sql =~ s/extract\(epoch from/unix_timestamp(/g;
+        $sql =~ s/extract\(epoch from/unix_timestamp\(/g;
     }
 
-    my $res = $self->schema->storage->dbh->selectall_arrayref($sql, {Columns => {}}, $id, $id, $id, $id);
+    my $res = $self->schema->storage->dbh->selectall_arrayref($sql, {Columns => {}}, $id, $id, $id, $id, $id, $id);
     return $self->render(json => { data => $res });
 }
 

--- a/t/environ/20-report-download.sh
+++ b/t/environ/20-report-download.sh
@@ -137,6 +137,37 @@ $mc/curl -I /download/tumbleweed/repo/oss/x86_64/cargo1.64-1.64.0-1.1.x86_64.rpm
 $mc/curl /rest/package/cargo1.64/stat_download_curr | grep '{"cnt_curr":3}'
 
 
+# Verify the total package download bug fix (where totals reset if no downloads on the global max date)
+# 1. Clear minion locks to allow running stat_agg_pkg again
+$mc/sql "delete from minion_locks"
+
+# 2-4. Insert dummy package, move package 1 totals, and insert new day downloads.
+# We execute these as a single semicolon-separated SQL block to guarantee the exact same transaction-time snapshot of now().
+$mc/sql "
+insert into metapkg (name) values ('dummy-pkg');
+insert into agg_download_pkg (period, dt, metapkg_id, folder_id, country, cnt) select 'total', now() - interval '1 day', id, 0, 'us', 10 from metapkg where name = 'dummy-pkg';
+update agg_download_pkg set dt = now() - interval '2 day' where metapkg_id = 1 and period = 'total';
+delete from agg_download_pkg where period = 'day' and dt = now() and metapkg_id = 1 and folder_id = 0 and country = 'us';
+insert into agg_download_pkg (period, dt, metapkg_id, folder_id, country, cnt) select 'day', now(), 1, 0, 'us', 5;
+"
+
+# 5. Run the aggregator again
+$mc/backstage/job stat_agg_schedule
+$mc/backstage/shoot
+
+# 6. Verify that package 1's total count accumulates correctly (8 + 5 = 13) rather than resetting to 5.
+# Use dynamic max(dt) subqueries to ensure test is 100% robust on midnight/hour boundaries.
+$mc/sql_test 13 == "select sum(cnt) from agg_download_pkg where metapkg_id = 1 and period = 'total' and dt = (select max(dt) from agg_download_pkg where metapkg_id = 1 and period = 'total')"
+$mc/curl /rest/package/1/stat_download | grep '"cnt_total":"13"'
+
+# 7. Clean up our test records so we don't interfere with the remaining table-count-sensitive tests
+$mc/sql "delete from agg_download_pkg where metapkg_id = 1 and period = 'total' and dt = (select max(dt) from agg_download_pkg where metapkg_id = 1 and period = 'total')"
+$mc/sql "delete from agg_download_pkg where metapkg_id = 1 and period = 'day' and dt = (select max(dt) from agg_download_pkg where metapkg_id = 1 and period = 'day')"
+$mc/sql "delete from agg_download_pkg where metapkg_id = (select id from metapkg where name = 'dummy-pkg')"
+$mc/sql "delete from metapkg where name = 'dummy-pkg'"
+$mc/sql "update agg_download_pkg set dt = now() where metapkg_id = 1 and period = 'total'"
+
+
 echo testing cleanup, for it populate old data
 $mc/sql "update agg_download_pkg set dt = dt - interval '1 month'"
 $mc/sql_test 72 == "select count(*) from agg_download_pkg"


### PR DESCRIPTION
The daily stat aggregator `_agg_total` was joining previous cumulative totals using the global maximum `'total'` date instead of the package-specific latest `'total'` date. If a package was not downloaded on the exact day of the last global run, it had no total record for that date. This resulted in a failed join, wiping out its entire historical statistics and resetting the cumulative count.

This fix:
1. Refactors `_agg_total` to join previous totals on a package-specific basis using an optimized subquery.
2. Scopes WebAPI queries `cnt_total` and `cnt_today` to the requested package ID to correctly show cumulative totals even during inactive days.
3. Adds a time-boundary-immune integration test in `20-report-download.sh` that freezes time relative to a single point to verify the fixes and prevent regressions.