### PR TITLE
Fix subfolder service redirect for symlinks pointing outside subtree

### DIFF
--- a/lib/MirrorCache/WebAPI/Plugin/RootLocal.pm
+++ b/lib/MirrorCache/WebAPI/Plugin/RootLocal.pm
@@ -99,13 +99,28 @@ sub is_dir {
 
 sub render_file {
     my ($self, $dm, $filepath, $not_miss) = @_;
-    # my $realpath = $self->realpath($filepath) unless $root_subtree;
-    # $filepath = $realpath if $realpath;
+    my $realpath = $self->realpath($filepath);
+    $filepath = $realpath if $realpath;
     my $c = $dm->c;
     my $redirect = $self->redirect($dm, $filepath);
     my $res;
     if ($redirect) {
-        $res = !!$c->redirect_to($redirect . $root_subtree . $filepath);
+        my $prefix = $root_subtree;
+        if ($root_subtree) {
+            my $inside = 0;
+            my $found = 0;
+            for my $root (@roots) {
+                if ( -e $root->[dir] . $root_subtree . $filepath ) {
+                    $inside = 1;
+                    $found = 1;
+                }
+                elsif ( -e $root->[dir] . $filepath ) {
+                    $found = 1;
+                }
+            }
+            $prefix = "" if $found && !$inside;
+        }
+        $res = !!$c->redirect_to($redirect . $prefix . $filepath);
     } else {
         my $rootpath = $self->rootpath($filepath);
         return !!$c->render(status => 404, text => "File $filepath not found") unless $rootpath;
@@ -162,7 +177,12 @@ sub realpath {
 
     if ($realpathlocal && (0 == rindex($realpathlocal, $rootpath, 0))) {
         my $realpath = substr($realpathlocal, length($rootpath));
-        return $realpath if $realpath ne $path;
+        if ($root_subtree && 0 == rindex($realpath, $root_subtree, 0)) {
+            my $relative_realpath = substr($realpath, length($root_subtree));
+            return $relative_realpath if $relative_realpath ne $path;
+        } else {
+            return $realpath if $realpath ne $path;
+        }
     }
     return undef;
 }

--- a/t/environ/15-local-symlink-subtree-outside.sh
+++ b/t/environ/15-local-symlink-subtree-outside.sh
@@ -1,0 +1,56 @@
+#!lib/test-in-container-environ.sh
+set -ex
+
+mc=$(environ mc $(pwd))
+$mc/start
+$mc/status
+
+mkdir -p $mc/dt/{folder1,folder2}
+echo $mc/dt/folder1/file1.1.dat | xargs -n 1 touch
+
+mkdir -p $mc/dt/updates/tool
+(
+cd $mc/dt/updates/tool/
+ln -s ../../folder1 v1
+)
+
+ls -la $mc/dt/updates/tool/
+
+# Register the folder in the database by requesting its mirrorlist on the headquarter
+$mc/curl -Is /download/updates/tool/v1/file1.1.dat.mirrorlist
+
+mcsub=$mc/sub
+
+$mcsub/gen_env MIRRORCACHE_ROOT="'$mc/dt:testhost.com:testhost.vpn'" \
+               MIRRORCACHE_SUBTREE=/updates \
+               MIRRORCACHE_TOP_FOLDERS=tool \
+               MIRRORCACHE_ROOT_COUNTRY=us
+
+$mcsub/start
+
+# Run folder sync to resolve symlink and populate the file in the database under the real folder
+$mc/backstage/job folder_sync_schedule_from_misses
+$mc/backstage/job folder_sync_schedule
+$mc/backstage/shoot
+
+# Verify that the file is in the database under folder1 (the real folder)
+$mc/sql_test 1 == "select count(*) from file where name = 'file1.1.dat'"
+
+# Now, request from subfolder service
+# Since file1.1.dat is now in the database under /folder1/file1.1.dat (which is outside /updates),
+# without the fix, RootLocal.pm's render_file will prepend /updates to the path, resulting in:
+# Location: http://testhost.com/updates/folder1/file1.1.dat
+# With the fix, it should be:
+# Location: http://testhost.com/folder1/file1.1.dat
+
+rc=0
+$mcsub/curl -I /tool/v1/file1.1.dat | grep 'Location: http://testhost.com/folder1/file1.1.dat' || rc=$?
+
+if [ $rc -ne 0 ]; then
+    echo "BUG DETECTED: Redirect location was wrong!"
+    # Print what the actual redirect location was
+    $mcsub/curl -I /tool/v1/file1.1.dat
+    exit 1
+else
+    echo "SUCCESS: Redirect location was correct!"
+fi


### PR DESCRIPTION
For MirrorCache instances running under a subfolder service (with MIRRORCACHE_SUBTREE configured), requests for symlinks that resolve to physical paths outside the subtree (e.g., a symlink under /updates/ pointing to /xxxx/...) were being redirected to incorrect, non-existent paths like /updates/xxxx/... which returned 404s.

This occurred because RootLocal.pm's render_file method was bypassing realpath resolution for subtree paths and unconditionally prepending the root_subtree prefix.

This change:
1. Always resolves the request path to its realpath in RootLocal.pm regardless of whether root_subtree is active.
2. Checks whether the resolved realpath resides inside or outside the subtree, dynamically omitting the prefix if the target is outside.
3. Adds an integration test (15-local-symlink-subtree-outside.sh) reproducing this exact scenario.